### PR TITLE
Fix column sort toggle and empty filter set persistence

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,9 +44,10 @@ export function App() {
         if (stored) {
           const parsed = JSON.parse(stored) as string[];
           if (Array.isArray(parsed)) {
-            return new Set<PRStateFilterKey>(
-              parsed.filter((k): k is PRStateFilterKey => k === 'draft' || k === 'open' || k === 'merged')
-            );
+            const valid = parsed.filter((k): k is PRStateFilterKey => k === 'draft' || k === 'open' || k === 'merged');
+            if (valid.length > 0) {
+              return new Set<PRStateFilterKey>(valid);
+            }
           }
         }
       } catch { /* ignore invalid stored data */ }
@@ -109,6 +110,8 @@ export function App() {
     setPRStateFilters((prev) => {
       const next = new Set(prev);
       if (next.has(key)) {
+        // Prevent deselecting the last active pill
+        if (next.size <= 1) return prev;
         next.delete(key);
       } else {
         next.add(key);
@@ -261,15 +264,16 @@ export function App() {
     setCursorIndex(0);
   }, []);
 
+  const sortRef = useRef(sort);
+  sortRef.current = sort;
+
   const handleSetSort = useCallback((key: SortMode) => {
-    setSort((prev) => {
-      if (prev === key) {
-        setSortDirection((d) => (d === 'desc' ? 'asc' : 'desc'));
-      } else {
-        setSortDirection('desc');
-      }
-      return key;
-    });
+    if (sortRef.current === key) {
+      setSortDirection((d) => (d === 'desc' ? 'asc' : 'desc'));
+    } else {
+      setSortDirection('desc');
+    }
+    setSort(key);
   }, []);
 
   const focusSearch = useCallback(() => {


### PR DESCRIPTION
## Summary

- Fix sort direction not toggling on repeated column header clicks (#28)
- Prevent empty PR state filter set from persisting to localStorage with no recovery (#29)

### Sort toggle fix
`handleSetSort` was calling `setSortDirection` inside the `setSort` updater function — a side effect in what should be pure. When clicking the same column, `setSort` returns the same value and React may bail out, causing the direction toggle to not fire. Fixed by using a ref to track the current sort key and separating the state updates.

### Empty filter fix
Two changes:
- Fall back to default filters (`['draft', 'open']`) when the parsed localStorage array is empty
- Prevent deselecting the last active pill in the UI (the toggle is a no-op when only one pill remains)

## Test plan
- [ ] Click a column header multiple times — sort direction should alternate each click
- [ ] Verify sort arrow (▲/▼) updates correctly on each click
- [ ] Click different column headers — direction should reset to descending
- [ ] Deselect all but one PR state pill — last pill should not be deselectable
- [ ] Clear `gh-dashboard-pr-state-filters` from localStorage, set to `[]`, reload — should show default filters

Closes #28, closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR state filter robustness to handle invalid or missing filter data gracefully
  * Prevented accidental deselection of all active PR state filters—at least one must remain selected
  * Enhanced sort column behavior to toggle direction when clicking the same column header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->