### PR TITLE
Stream results into table as they load

### DIFF
--- a/src/hooks/useGithubData.ts
+++ b/src/hooks/useGithubData.ts
@@ -18,7 +18,7 @@ interface UseGithubDataResult {
  * Merge an enriched PR into the items array, replacing the existing entry by id.
  */
 function replaceItem(prev: DashboardItem[], updated: DashboardItem): DashboardItem[] {
-  const idx = prev.findIndex((item) => item.id === updated.id);
+  const idx = prev.findIndex((item) => item.id === updated.id && item.kind === updated.kind);
   if (idx === -1) return prev;
   const next = [...prev];
   next[idx] = updated;


### PR DESCRIPTION
## Summary

- Progressively stream items into the table as each API fetch resolves, instead of waiting for all calls to complete
- PRs and issues appear as soon as their respective fetch completes
- PR enrichment (CI status, reviews, requested reviewer) updates each row individually as it resolves
- Clears the table at the start of a refresh to avoid stale data mixing with fresh results

## How it works

**Before:** `setItems()` was called once after all fetching and enrichment completed. The table stayed empty during the entire load.

**After:** Each fetch (`fetchUserPRs`, `fetchUserIssues`, or per-repo fetches) calls `setItems(prev => [...prev, ...newItems])` as soon as it resolves. Each PR enrichment call then uses `replaceItem()` to swap the unenriched PR with its enriched version in-place.

## Related

- #48 — Table virtualization would complement this for very large item counts
- Fixes #68

## Test plan

- [ ] Verify items appear in the table progressively during initial load
- [ ] Verify CI status and review badges update on rows after they first appear
- [ ] Verify the rate limit counter still increments as expected
- [ ] Verify refresh (`r` key) clears and re-streams items
- [ ] Run `npm test` — all existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched from batch loading to incremental streaming for pull requests and issues so items appear progressively as they load.
  * Made enrichment incremental so individual PRs update the list as soon as ready, improving perceived responsiveness.
  * Improved refresh flow to reset items at refresh start and guard updates on cancellation to prevent stale state.

* **Bug Fixes**
  * Better handling of per-repo fetch failures so partial results are collected without blocking other updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->