### PR TITLE
Replace filter pills with dropdown menus

### DIFF
--- a/src/components/FilterBar.test.tsx
+++ b/src/components/FilterBar.test.tsx
@@ -26,102 +26,86 @@ function renderFilterBar(overrides: Partial<React.ComponentProps<typeof FilterBa
   return { ...render(<FilterBar {...defaults} />), props: defaults };
 }
 
-describe('FilterBar', () => {
-  it('renders all filter pills', () => {
+describe('FilterBar dropdowns', () => {
+  it('renders all dropdown triggers', () => {
     renderFilterBar();
-    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Owner:')).toBeInTheDocument();
+    expect(screen.getByText('Type:')).toBeInTheDocument();
+    expect(screen.getByText('Filter:')).toBeInTheDocument();
+    expect(screen.getByText('State:')).toBeInTheDocument();
+  });
+
+  it('shows username in ownership trigger when user-specific filter is active', () => {
+    renderFilterBar({ ownershipFilter: 'created', username: 'octocat' });
+    expect(screen.getByText('@octocat')).toBeInTheDocument();
+  });
+
+  it('shows "Everyone" in ownership trigger when everyone filter is active', () => {
+    renderFilterBar({ ownershipFilter: 'everyone', username: 'octocat' });
+    expect(screen.getByText('Everyone')).toBeInTheDocument();
+  });
+
+  it('shows filter options when trigger is clicked', async () => {
+    renderFilterBar();
+    await userEvent.click(screen.getByText('Filter:'));
     expect(screen.getByText('Failing CI')).toBeInTheDocument();
     expect(screen.getByText('Needs Review')).toBeInTheDocument();
     expect(screen.getByText('Review Requested')).toBeInTheDocument();
   });
 
-  it('highlights the active filter', () => {
-    renderFilterBar({ active: 'failing' });
-    expect(screen.getByText('Failing CI')).toHaveClass('filter-active');
-    expect(screen.getByText('All')).not.toHaveClass('filter-active');
-  });
-
-  it('calls onFilter when a filter pill is clicked', async () => {
+  it('calls onFilter when a filter option is selected', async () => {
     const onFilter = vi.fn();
     renderFilterBar({ onFilter });
+    await userEvent.click(screen.getByText('Filter:'));
     await userEvent.click(screen.getByText('Needs Review'));
     expect(onFilter).toHaveBeenCalledWith('needs-review');
   });
 
-  it('shows username when a user-specific ownership filter is active', () => {
-    renderFilterBar({ ownershipFilter: 'created', username: 'octocat' });
-    expect(screen.getByText('@octocat')).toBeInTheDocument();
-  });
-
-  it('shows "Everyone" button for the everyone filter', () => {
-    renderFilterBar({ ownershipFilter: 'everyone', username: 'octocat' });
-    expect(screen.getByText('Everyone')).toBeInTheDocument();
-  });
-
-  it('highlights the active ownership filter', () => {
-    renderFilterBar({ ownershipFilter: 'created', username: 'octocat' });
-    expect(screen.getByText('@octocat')).toHaveClass('filter-active');
-  });
-
-  it('calls onSetOwnership when an ownership pill is clicked', async () => {
+  it('calls onSetOwnership when an ownership option is selected', async () => {
     const onSetOwnership = vi.fn();
-    renderFilterBar({ ownershipFilter: 'created', onSetOwnership });
+    renderFilterBar({ onSetOwnership });
+    await userEvent.click(screen.getByText('Owner:'));
     await userEvent.click(screen.getByText('Everyone'));
     expect(onSetOwnership).toHaveBeenCalledWith('everyone');
   });
 
-  it('renders all ownership filter options', () => {
+  it('shows all ownership options in dropdown', async () => {
     renderFilterBar({ ownershipFilter: 'everyone' });
-    expect(screen.getByText('Created')).toBeInTheDocument();
-    expect(screen.getByText('Assigned')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Owner:'));
+    expect(screen.getByText('Created by me')).toBeInTheDocument();
+    expect(screen.getByText('Assigned to me')).toBeInTheDocument();
     expect(screen.getByText('Involved')).toBeInTheDocument();
-    expect(screen.getByText('Everyone')).toBeInTheDocument();
   });
 });
 
-describe('FilterBar PR state pills', () => {
-  it('renders Draft, Open, and Merged pills', () => {
-    renderFilterBar();
-    expect(screen.getByText('Draft')).toBeInTheDocument();
-    expect(screen.getByText('Open')).toBeInTheDocument();
-    expect(screen.getByText('Merged')).toBeInTheDocument();
+describe('FilterBar PR state dropdown', () => {
+  it('shows active states in trigger label', () => {
+    renderFilterBar({ prStateFilters: new Set<PRStateFilterKey>(['draft', 'open']) });
+    expect(screen.getByText('Draft, Open')).toBeInTheDocument();
   });
 
-  it('marks Draft and Open as active by default', () => {
-    renderFilterBar();
-    const draft = screen.getByText('Draft');
-    const open = screen.getByText('Open');
-    const merged = screen.getByText('Merged');
-
-    expect(draft.className).toContain('pr-state-active');
-    expect(open.className).toContain('pr-state-active');
-    expect(merged.className).not.toContain('pr-state-active');
-  });
-
-  it('marks Merged as active when included in prStateFilters', () => {
-    renderFilterBar({ prStateFilters: new Set<PRStateFilterKey>(['draft', 'open', 'merged']) });
-    expect(screen.getByText('Merged').className).toContain('pr-state-active');
-  });
-
-  it('calls onTogglePRState when a state pill is clicked', async () => {
+  it('calls onTogglePRState when a state option is toggled', async () => {
     const user = userEvent.setup();
     const { props } = renderFilterBar();
-
+    await user.click(screen.getByText('State:'));
     await user.click(screen.getByText('Merged'));
     expect(props.onTogglePRState).toHaveBeenCalledWith('merged');
-
-    await user.click(screen.getByText('Draft'));
-    expect(props.onTogglePRState).toHaveBeenCalledWith('draft');
   });
 
-  it('shows no active state pills when prStateFilters is empty', () => {
-    renderFilterBar({ prStateFilters: new Set<PRStateFilterKey>() });
-    const draft = screen.getByText('Draft');
-    const open = screen.getByText('Open');
-    const merged = screen.getByText('Merged');
+  it('keeps dropdown open after toggling (multi-select)', async () => {
+    const user = userEvent.setup();
+    renderFilterBar();
+    await user.click(screen.getByText('State:'));
+    await user.click(screen.getByText('Merged'));
+    // Dropdown should still be open — Draft and Open should still be visible
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+});
 
-    expect(draft.className).not.toContain('pr-state-active');
-    expect(open.className).not.toContain('pr-state-active');
-    expect(merged.className).not.toContain('pr-state-active');
+describe('FilterBar search', () => {
+  it('renders search input', () => {
+    renderFilterBar();
+    expect(screen.getByPlaceholderText('Search… ( / )')).toBeInTheDocument();
   });
 });

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,33 +1,34 @@
 import React, { useState, useEffect, useRef, type RefObject } from 'react';
 import type { FilterMode, ItemTypeFilter, RepoConfig, PRStateFilterKey, OwnershipFilter } from '../types.js';
+import { FilterDropdown, type FilterDropdownOption } from './FilterDropdown.js';
 
-const FILTERS: { key: FilterMode; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'failing', label: 'Failing CI' },
-  { key: 'needs-review', label: 'Needs Review' },
-  { key: 'review-requested', label: 'Review Requested' },
-  { key: 'new-activity', label: 'New Activity' },
-  { key: 'merge-ready', label: '🚀 Ready to Merge' },
-  { key: 'stale', label: 'Stale' },
+const OWNERSHIP_OPTIONS: FilterDropdownOption<OwnershipFilter>[] = [
+  { key: 'created', label: 'Created by me' },
+  { key: 'assigned', label: 'Assigned to me' },
+  { key: 'involved', label: 'Involved' },
+  { key: 'everyone', label: 'Everyone' },
 ];
 
-const ITEM_TYPES: { key: ItemTypeFilter; label: string }[] = [
+const ITEM_TYPE_OPTIONS: FilterDropdownOption<ItemTypeFilter>[] = [
   { key: 'both', label: 'Both' },
   { key: 'prs', label: 'PRs' },
   { key: 'issues', label: 'Issues' },
 ];
 
-const PR_STATE_FILTERS: { key: PRStateFilterKey; label: string }[] = [
-  { key: 'draft', label: 'Draft' },
-  { key: 'open', label: 'Open' },
-  { key: 'merged', label: 'Merged' },
+const FILTER_OPTIONS: FilterDropdownOption<FilterMode>[] = [
+  { key: 'all', label: 'All' },
+  { key: 'failing', label: 'Failing CI' },
+  { key: 'needs-review', label: 'Needs Review' },
+  { key: 'review-requested', label: 'Review Requested' },
+  { key: 'new-activity', label: 'New Activity' },
+  { key: 'merge-ready', label: 'Ready to Merge' },
+  { key: 'stale', label: 'Stale' },
 ];
 
-const OWNERSHIP_FILTERS: { key: OwnershipFilter; label: string; shortLabel: string }[] = [
-  { key: 'created', label: 'Created by me', shortLabel: 'Created' },
-  { key: 'assigned', label: 'Assigned to me', shortLabel: 'Assigned' },
-  { key: 'involved', label: 'Involved', shortLabel: 'Involved' },
-  { key: 'everyone', label: 'Everyone', shortLabel: 'Everyone' },
+const PR_STATE_OPTIONS: FilterDropdownOption<PRStateFilterKey>[] = [
+  { key: 'draft', label: 'Draft', color: 'var(--text-muted)' },
+  { key: 'open', label: 'Open', color: 'var(--green)' },
+  { key: 'merged', label: 'Merged', color: 'var(--purple)' },
 ];
 
 interface FilterBarProps {
@@ -52,7 +53,6 @@ export function FilterBar({ active, onFilter, ownershipFilter, onSetOwnership, u
   const hiddenCount = hiddenRepos?.length ?? 0;
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     if (!showHiddenDropdown) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -64,89 +64,70 @@ export function FilterBar({ active, onFilter, ownershipFilter, onSetOwnership, u
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showHiddenDropdown]);
 
-  // Reset dropdown when all repos are restored
   useEffect(() => {
     if (hiddenCount === 0) setShowHiddenDropdown(false);
   }, [hiddenCount]);
 
   return (
     <div className="filter-bar">
-      {OWNERSHIP_FILTERS.map(({ key, label, shortLabel }) => (
-        <button
-          key={key}
-          className={`filter-pill ${ownershipFilter === key ? 'filter-active' : ''}`}
-          onClick={() => onSetOwnership(key)}
-          title={`${label} (m)`}
-        >
-          {key !== 'everyone' && ownershipFilter === key && username
+      <FilterDropdown
+        categoryLabel="Owner"
+        options={OWNERSHIP_OPTIONS}
+        value={ownershipFilter}
+        onSelect={onSetOwnership}
+        renderTriggerLabel={() =>
+          ownershipFilter !== 'everyone' && username
             ? `@${username}`
-            : shortLabel}
-        </button>
-      ))}
-      <span className="filter-divider" />
-      {ITEM_TYPES.map(({ key, label }) => (
-        <button
-          key={key}
-          className={`filter-pill ${itemTypeFilter === key ? 'filter-active' : ''}`}
-          onClick={() => onSetItemType(key)}
-          title={`Show ${label} (t)`}
-        >
-          {label}
-        </button>
-      ))}
-      <span className="filter-divider" />
-      {FILTERS.map(({ key, label }) => (
-        <button
-          key={key}
-          className={`filter-pill ${active === key ? 'filter-active' : ''}`}
-          onClick={() => onFilter(key)}
-        >
-          {label}
-        </button>
-      ))}
+            : OWNERSHIP_OPTIONS.find((o) => o.key === ownershipFilter)!.label
+        }
+      />
+      <FilterDropdown
+        categoryLabel="Type"
+        options={ITEM_TYPE_OPTIONS}
+        value={itemTypeFilter}
+        onSelect={onSetItemType}
+      />
+      <FilterDropdown
+        categoryLabel="Filter"
+        options={FILTER_OPTIONS}
+        value={active}
+        onSelect={onFilter}
+      />
       {hiddenCount > 0 && (
-        <>
-          <span className="filter-divider" />
-          <div className="hidden-repos-wrapper" ref={dropdownRef}>
-            <button
-              className="filter-pill hidden-repos-pill"
-              onClick={() => setShowHiddenDropdown((prev) => !prev)}
-              title="Show hidden repositories"
-            >
-              {hiddenCount} hidden
-            </button>
-            {showHiddenDropdown && (
-              <div className="hidden-repos-dropdown">
-                <div className="hidden-repos-header">Hidden Repositories</div>
-                {hiddenRepos?.map((repo) => (
-                  <button
-                    key={`${repo.owner}/${repo.name}`}
-                    className="hidden-repo-item"
-                    onClick={() => {
-                      onRestoreRepo?.(repo.owner, repo.name);
-                    }}
-                    title={`Restore ${repo.owner}/${repo.name}`}
-                  >
-                    <span className="hidden-repo-name">{repo.owner}/{repo.name}</span>
-                    <span className="hidden-repo-restore">restore</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        </>
+        <div className="hidden-repos-wrapper" ref={dropdownRef}>
+          <button
+            className="filter-dropdown-trigger hidden-repos-trigger"
+            onClick={() => setShowHiddenDropdown((prev) => !prev)}
+            title="Show hidden repositories"
+          >
+            <span className="filter-dropdown-value hidden-repos-label">{hiddenCount} hidden</span>
+          </button>
+          {showHiddenDropdown && (
+            <div className="filter-dropdown-panel hidden-repos-panel">
+              <div className="hidden-repos-header">Hidden Repositories</div>
+              {hiddenRepos?.map((repo) => (
+                <button
+                  key={`${repo.owner}/${repo.name}`}
+                  className="hidden-repo-item"
+                  onClick={() => {
+                    onRestoreRepo?.(repo.owner, repo.name);
+                  }}
+                  title={`Restore ${repo.owner}/${repo.name}`}
+                >
+                  <span className="hidden-repo-name">{repo.owner}/{repo.name}</span>
+                  <span className="hidden-repo-restore">restore</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       )}
-      <span className="filter-divider" />
-      {PR_STATE_FILTERS.map(({ key, label }) => (
-        <button
-          key={key}
-          className={`filter-pill pr-state-pill pr-state-${key} ${prStateFilters.has(key) ? 'pr-state-active' : ''}`}
-          onClick={() => onTogglePRState(key)}
-        >
-          {label}
-        </button>
-      ))}
-      <span className="filter-divider" />
+      <FilterDropdown
+        categoryLabel="State"
+        options={PR_STATE_OPTIONS}
+        values={prStateFilters}
+        onToggle={onTogglePRState}
+      />
       <input
         ref={searchInputRef}
         type="text"

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+export interface FilterDropdownOption<K extends string> {
+  key: K;
+  label: string;
+  color?: string;
+}
+
+interface FilterDropdownProps<K extends string> {
+  categoryLabel: string;
+  options: FilterDropdownOption<K>[];
+  value?: K;
+  values?: Set<K>;
+  onSelect?: (key: K) => void;
+  onToggle?: (key: K) => void;
+  renderTriggerLabel?: () => string;
+}
+
+export function FilterDropdown<K extends string>({
+  categoryLabel,
+  options,
+  value,
+  values,
+  onSelect,
+  onToggle,
+  renderTriggerLabel,
+}: FilterDropdownProps<K>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const isMulti = values !== undefined && onToggle !== undefined;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const triggerLabel = renderTriggerLabel
+    ? renderTriggerLabel()
+    : isMulti
+      ? options.filter((o) => values!.has(o.key)).map((o) => o.label).join(', ') || 'None'
+      : options.find((o) => o.key === value)?.label ?? '';
+
+  const handleOptionClick = (key: K) => {
+    if (isMulti) {
+      onToggle!(key);
+    } else {
+      onSelect?.(key);
+      setIsOpen(false);
+    }
+  };
+
+  const isActive = (key: K) => isMulti ? values!.has(key) : value === key;
+
+  return (
+    <div className="filter-dropdown" ref={wrapperRef}>
+      <button
+        className={`filter-dropdown-trigger ${isOpen ? 'filter-dropdown-open' : ''}`}
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+      >
+        <span className="filter-dropdown-category">{categoryLabel}:</span>
+        <span className="filter-dropdown-value">{triggerLabel}</span>
+        <span className={`filter-dropdown-chevron ${isOpen ? 'filter-dropdown-chevron-up' : ''}`}>&#9662;</span>
+      </button>
+      {isOpen && (
+        <div className="filter-dropdown-panel" role="listbox" aria-label={categoryLabel}>
+          {options.map((option) => {
+            const active = isActive(option.key);
+            return (
+              <button
+                key={option.key}
+                className={`filter-dropdown-option ${active ? 'filter-dropdown-option-active' : ''}`}
+                onClick={() => handleOptionClick(option.key)}
+                role="option"
+                aria-selected={active}
+              >
+                <span className="filter-dropdown-check">{active ? '✓' : ''}</span>
+                {option.color && (
+                  <span
+                    className="filter-dropdown-dot"
+                    style={{ background: option.color }}
+                  />
+                )}
+                <span className="filter-dropdown-option-label">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/FilterBar.css
+++ b/src/styles/FilterBar.css
@@ -3,117 +3,133 @@
   display: flex;
   gap: 8px;
   padding: 12px 0;
+  align-items: center;
 }
 
-.filter-pill {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  color: var(--text-muted);
-  padding: 4px 14px;
-  border-radius: 20px;
-  cursor: pointer;
-  font-size: 13px;
-  transition: all 0.15s;
-}
-
-.filter-pill:hover {
-  color: var(--text);
-  border-color: var(--text-muted);
-}
-
-.filter-active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
-.filter-active:hover {
-  border-color: var(--accent);
-}
-
-.filter-divider {
-  width: 1px;
-  height: 20px;
-  background: var(--border);
-  align-self: center;
-}
-
-/* ── PR State Pills ─────────────────────────────────────────── */
-.pr-state-pill {
-  opacity: 0.5;
-  border-style: dashed;
-}
-
-.pr-state-pill:hover {
-  opacity: 0.8;
-}
-
-.pr-state-pill.pr-state-active {
-  opacity: 1;
-  border-style: solid;
-}
-
-.pr-state-pill.pr-state-draft.pr-state-active {
-  background: var(--bg-surface);
-  color: var(--text-muted);
-  border-color: var(--text-muted);
-}
-
-.pr-state-pill.pr-state-open.pr-state-active {
-  background: rgba(63, 185, 80, 0.15);
-  color: var(--green);
-  border-color: rgba(63, 185, 80, 0.4);
-}
-
-.pr-state-pill.pr-state-merged.pr-state-active {
-  background: rgba(188, 140, 255, 0.15);
-  color: var(--purple);
-  border-color: rgba(188, 140, 255, 0.4);
-}
-
-/* ── Search Input ──────────────────────────────────────────── */
-.search-input {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  color: var(--text);
-  padding: 4px 12px;
-  border-radius: 20px;
-  font-size: 13px;
-  width: 200px;
-  outline: none;
-  transition: border-color 0.15s, width 0.2s;
-}
-
-.search-input::placeholder {
-  color: var(--text-subtle);
-}
-
-.search-input:focus {
-  border-color: var(--accent);
-  width: 280px;
-}
-
-/* ── Hidden Repos Indicator ────────────────────────────────── */
-.hidden-repos-wrapper {
+/* ── Filter Dropdown ───────────────────────────────────────── */
+.filter-dropdown {
   position: relative;
 }
 
-.filter-pill.hidden-repos-pill {
-  color: var(--yellow);
-  border-color: var(--yellow);
+.filter-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 10px 5px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: border-color 0.15s, background 0.15s;
+  white-space: nowrap;
 }
 
-.hidden-repos-dropdown {
+.filter-dropdown-trigger:hover {
+  border-color: var(--text-muted);
+}
+
+.filter-dropdown-trigger.filter-dropdown-open {
+  border-color: var(--accent);
+}
+
+.filter-dropdown-category {
+  color: var(--text-subtle);
+  font-weight: 500;
+}
+
+.filter-dropdown-value {
+  color: var(--text);
+}
+
+.filter-dropdown-chevron {
+  font-size: 9px;
+  color: var(--text-subtle);
+  transition: transform 0.15s;
+  line-height: 1;
+}
+
+.filter-dropdown-chevron-up {
+  transform: rotate(180deg);
+}
+
+.filter-dropdown-panel {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + 4px);
   left: 0;
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  min-width: 240px;
+  min-width: 180px;
   z-index: 50;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   overflow: hidden;
+}
+
+.filter-dropdown-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.filter-dropdown-option:last-child {
+  border-bottom: none;
+}
+
+.filter-dropdown-option:hover {
+  background: var(--bg-hover);
+}
+
+.filter-dropdown-option-active {
+  color: var(--text);
+}
+
+.filter-dropdown-check {
+  width: 14px;
+  text-align: center;
+  color: var(--accent);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.filter-dropdown-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.filter-dropdown-option-label {
+  flex: 1;
+}
+
+/* ── Hidden Repos ──────────────────────────────────────────── */
+.hidden-repos-wrapper {
+  position: relative;
+}
+
+.hidden-repos-trigger {
+  border-color: var(--yellow);
+}
+
+.hidden-repos-label {
+  color: var(--yellow);
+}
+
+.hidden-repos-panel {
+  min-width: 240px;
 }
 
 .hidden-repos-header {
@@ -157,4 +173,27 @@
   color: var(--accent);
   font-size: 12px;
   font-weight: 500;
+}
+
+/* ── Search Input ──────────────────────────────────────────── */
+.search-input {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  width: 200px;
+  outline: none;
+  transition: border-color 0.15s, width 0.2s;
+  margin-left: auto;
+}
+
+.search-input::placeholder {
+  color: var(--text-subtle);
+}
+
+.search-input:focus {
+  border-color: var(--accent);
+  width: 280px;
 }


### PR DESCRIPTION
## Summary

- Create reusable `FilterDropdown` component supporting both single-select and multi-select modes
- Replace 17 individual pill buttons with 4 compact dropdown selectors: Owner, Type, Filter, State
- Single-select dropdowns (Owner, Type, Filter) close on selection
- Multi-select dropdown (State) stays open for toggling Draft/Open/Merged with colored dot indicators
- Trigger buttons show `Category: Value` format with chevron indicator
- Search input pushed to far right with `margin-left: auto`
- Click-outside-to-close behavior on all dropdowns
- ARIA attributes for accessibility (`aria-expanded`, `aria-haspopup`, `role="listbox"/"option"`)

## Before / After

**Before:** 17 pills in a single row, visually cluttered
**After:** 4 compact dropdowns + search, clean and scannable

## Test plan

- [ ] Verify each dropdown opens, shows correct options, and selects correctly
- [ ] Verify State dropdown stays open for multi-select toggling
- [ ] Verify keyboard shortcuts (`m`, `t`, `f`) still cycle values
- [ ] Verify hidden repos dropdown still works when repos are hidden
- [ ] Verify search input still works with `/` shortcut
- [ ] Run `npm test` — all 177 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dropdown-based filter menus replacing individual filter pills.

* **Refactor**
  * Migrated filter controls to dropdown components for streamlined interaction.
  * Enhanced search input styling and layout positioning.

* **Style**
  * Updated filter bar styling with refined dropdown visual design.

* **Tests**
  * Updated filter tests for dropdown interaction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->