### PR TITLE
Fix jumpy UI on hover

### DIFF
--- a/src/styles/FilterBar.css
+++ b/src/styles/FilterBar.css
@@ -185,7 +185,7 @@
   font-size: 13px;
   width: 200px;
   outline: none;
-  transition: border-color 0.15s, width 0.2s;
+  transition: border-color 0.15s;
   margin-left: auto;
 }
 
@@ -195,7 +195,6 @@
 
 .search-input:focus {
   border-color: var(--accent);
-  width: 280px;
 }
 
 /* ── Label Filter ──────────────────────────────────────────── */

--- a/src/styles/PRTable.css
+++ b/src/styles/PRTable.css
@@ -324,7 +324,8 @@
 }
 
 .repo-hide-btn {
-  display: none;
+  visibility: hidden;
+  display: inline-flex;
   background: none;
   border: 1px solid var(--border);
   color: var(--text-subtle);
@@ -338,7 +339,7 @@
 
 .pr-row:hover .repo-hide-btn,
 .pr-row:focus-within .repo-hide-btn {
-  display: inline-flex;
+  visibility: visible;
 }
 
 .repo-hide-btn:focus-visible {


### PR DESCRIPTION
## Summary
- Fix repo hide button causing horizontal layout shift on row hover by using `visibility: hidden/visible` instead of `display: none/inline-flex`
- Remove search input width expansion on focus (200px → 280px) which shifted adjacent filter controls

## Test plan
- [ ] Hover over table rows rapidly — no horizontal shifting or jumpiness
- [ ] Verify the repo hide button (✕) still appears on hover and works correctly
- [ ] Click into the search input — no filter bar layout shift
- [ ] Run `npx vitest run` — all 181 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated search input focus behavior: the border color now changes when focused, without adjusting the input width.
* Improved button visibility in the PR table: buttons maintain their layout space when hidden and reappear on hover or focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->