### PR TITLE
Add manual refresh button next to countdown timer

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -183,6 +183,7 @@ export function App() {
         unseenCount={unseenCount}
         onOpenRepos={openRepos}
         onSignOut={handleSignOut}
+        onRefresh={handleRefresh}
         autoRefreshSecondsLeft={autoRefreshSecondsLeft}
         rateLimit={rateLimit}
       />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ interface HeaderProps {
   unseenCount: number;
   onOpenRepos: () => void;
   onSignOut: () => void;
+  onRefresh: () => void;
   autoRefreshSecondsLeft: number | null;
   rateLimit: RateLimit | null;
 }
@@ -27,6 +28,7 @@ export function Header({
   unseenCount,
   onOpenRepos,
   onSignOut,
+  onRefresh,
   autoRefreshSecondsLeft,
   rateLimit,
 }: HeaderProps) {
@@ -58,6 +60,15 @@ export function Header({
             ↻ {formatCountdown(autoRefreshSecondsLeft)}
           </span>
         )}
+        <button
+          className="refresh-btn"
+          onClick={onRefresh}
+          disabled={loading}
+          title="Refresh now (r)"
+          aria-label="Refresh data"
+        >
+          {loading ? <span className="spinner" /> : '↻'}
+        </button>
         {rateLimit && (
           <span
             className={`rate-limit ${rateLimitCritical ? 'rate-limit-critical' : rateLimitWarning ? 'rate-limit-warning' : ''}`}

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -65,6 +65,37 @@
   font-variant-numeric: tabular-nums;
 }
 
+.refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.refresh-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.refresh-btn .spinner {
+  width: 14px;
+  height: 14px;
+}
+
 /* ── Rate Limit ─────────────────────────────────────────────── */
 .rate-limit {
   font-size: 12px;


### PR DESCRIPTION
## Summary
- Add a refresh button (↻) in the header next to the auto-refresh countdown timer
- Button triggers an immediate data refresh and resets the countdown timer
- Shows a loading spinner while fetching, disabled during active requests
- Includes `aria-label` for accessibility and tooltip showing the `r` keyboard shortcut

Closes #85

## Test plan
- [ ] Verify the refresh button appears next to the countdown timer
- [ ] Click the button and confirm data refreshes immediately and the timer resets
- [ ] Verify the button shows a spinner and is disabled while loading
- [ ] Verify the `r` keyboard shortcut still works alongside the button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual refresh button to the header UI that allows users to trigger an immediate data refresh with a single click. The button displays a loading indicator while refreshing and is disabled during the operation to prevent concurrent requests. The refresh action resets the auto-refresh countdown timer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->