### PR TITLE
Fix duplicate spinner in upper right when loading records

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,7 +49,6 @@ export function Header({
         )}
       </div>
       <div className="header-right">
-        {loading && <span className="spinner" />}
         {lastRefresh && !loading && (
           <span className="last-refresh">
             {lastRefresh.toLocaleTimeString()}


### PR DESCRIPTION
## Summary
- Remove the standalone spinner in the header that duplicated the refresh button's built-in loading spinner
- When `loading` is true, only the refresh button spinner is shown instead of two side-by-side spinners

Fixes #89

## Test plan
- [ ] Trigger a records load and verify only one spinner appears in the upper right
- [ ] Verify the refresh button shows its spinner animation while loading
- [ ] Verify last-refresh time and countdown reappear after loading completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant loading spinner from the header that was duplicating feedback already provided by the refresh button spinner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->