### PR TITLE
Fix CI failure indicator incorrectly flagging PRs with passing reruns

### DIFF
--- a/src/github/checks.test.ts
+++ b/src/github/checks.test.ts
@@ -168,14 +168,14 @@ describe('getCheckStatus', () => {
     expect(await getCheckStatus(octokit, 'o', 'r', 'ref')).toBe('mixed');
   });
 
-  it('deduplicates check runs by name, keeping only the latest', async () => {
+  it('deduplicates check runs by app+name, keeping only the latest', async () => {
     const octokit = mockOctokit({
       checks: {
         listForRef: vi.fn().mockResolvedValue({
           data: {
             check_runs: [
-              { name: 'test', status: 'completed', conclusion: 'failure', started_at: '2024-01-01T00:00:00Z' },
-              { name: 'test', status: 'completed', conclusion: 'success', started_at: '2024-01-01T01:00:00Z' },
+              { name: 'test', app: { id: 1 }, status: 'completed', conclusion: 'failure', started_at: '2024-01-01T00:00:00Z' },
+              { name: 'test', app: { id: 1 }, status: 'completed', conclusion: 'success', started_at: '2024-01-01T01:00:00Z' },
             ],
           },
         }),
@@ -190,15 +190,31 @@ describe('getCheckStatus', () => {
         listForRef: vi.fn().mockResolvedValue({
           data: {
             check_runs: [
-              { name: 'ci/build', status: 'completed', conclusion: 'failure', started_at: '2024-01-01T00:00:00Z' },
-              { name: 'ci/build', status: 'completed', conclusion: 'success', started_at: '2024-01-01T02:00:00Z' },
-              { name: 'ci/lint', status: 'completed', conclusion: 'success', started_at: '2024-01-01T00:00:00Z' },
+              { name: 'ci/build', app: { id: 1 }, status: 'completed', conclusion: 'failure', started_at: '2024-01-01T00:00:00Z' },
+              { name: 'ci/build', app: { id: 1 }, status: 'completed', conclusion: 'success', started_at: '2024-01-01T02:00:00Z' },
+              { name: 'ci/lint', app: { id: 1 }, status: 'completed', conclusion: 'success', started_at: '2024-01-01T00:00:00Z' },
             ],
           },
         }),
       },
     });
     expect(await getCheckStatus(octokit, 'o', 'r', 'ref')).toBe('success');
+  });
+
+  it('keeps same-named checks from different apps separate', async () => {
+    const octokit = mockOctokit({
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: {
+            check_runs: [
+              { name: 'test', app: { id: 1 }, status: 'completed', conclusion: 'success', started_at: '2024-01-01T00:00:00Z' },
+              { name: 'test', app: { id: 2 }, status: 'completed', conclusion: 'failure', started_at: '2024-01-01T00:00:00Z' },
+            ],
+          },
+        }),
+      },
+    });
+    expect(await getCheckStatus(octokit, 'o', 'r', 'ref')).toBe('failure');
   });
 
   it('returns "none" when the API call throws', async () => {

--- a/src/github/checks.ts
+++ b/src/github/checks.ts
@@ -17,15 +17,17 @@ export async function getCheckStatus(
     const allRuns = data.check_runs;
     if (allRuns.length === 0) return 'none';
 
-    // Keep only the latest run per check name (reruns create duplicate entries)
-    const latestByName = new Map<string, (typeof allRuns)[number]>();
+    // Keep only the latest run per app+name (reruns create duplicate entries;
+    // different apps can emit checks with the same name)
+    const latestByKey = new Map<string, (typeof allRuns)[number]>();
     for (const run of allRuns) {
-      const existing = latestByName.get(run.name);
+      const key = `${run.app?.id ?? 'unknown'}:${run.name}`;
+      const existing = latestByKey.get(key);
       if (!existing || new Date(run.started_at ?? 0) > new Date(existing.started_at ?? 0)) {
-        latestByName.set(run.name, run);
+        latestByKey.set(key, run);
       }
     }
-    const runs = [...latestByName.values()];
+    const runs = [...latestByKey.values()];
 
     const failConclusions = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
     if (runs.some((r) => r.conclusion && failConclusions.has(r.conclusion)))

--- a/src/github/details.ts
+++ b/src/github/details.ts
@@ -142,18 +142,20 @@ function parseTimelineEvents(events: any[]): TimelineEvent[] {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-// Keep only the latest run per check name (reruns create duplicate entries)
-function deduplicateCheckRuns<T extends { name: string; started_at?: string | null }>(
+// Keep only the latest run per app+name (reruns create duplicate entries;
+// different apps can emit checks with the same name)
+function deduplicateCheckRuns<T extends { name: string; started_at?: string | null; app?: { id?: number | null } | null }>(
   runs: T[]
 ): T[] {
-  const latestByName = new Map<string, T>();
+  const latestByKey = new Map<string, T>();
   for (const run of runs) {
-    const existing = latestByName.get(run.name);
+    const key = `${run.app?.id ?? 'unknown'}:${run.name}`;
+    const existing = latestByKey.get(key);
     if (!existing || new Date(run.started_at ?? 0) > new Date(existing.started_at ?? 0)) {
-      latestByName.set(run.name, run);
+      latestByKey.set(key, run);
     }
   }
-  return [...latestByName.values()];
+  return [...latestByKey.values()];
 }
 
 export async function getPRDetails(


### PR DESCRIPTION
## Summary
- Deduplicate check runs by name, keeping only the latest run (by `started_at` timestamp) before evaluating CI status
- Apply the same deduplication in the detail panel's check run list
- Add tests covering the rerun deduplication logic

## Root cause
GitHub's `checks.listForRef` API returns **all** check runs for a ref, including previous attempts. When a check fails and is rerun successfully, both the old failed run and the new passing run appear in the response. The existing logic used `runs.some(r => failConclusions.has(r.conclusion))` which matched the stale failed run, incorrectly marking the PR as failing.

## Test plan
- [x] Existing tests updated with `name`/`started_at` fields
- [x] New test: deduplicates check runs by name, keeping only the latest
- [x] New test: handles reruns where old failure is superseded by new success
- [x] All 28 tests pass
- [ ] Manual verification: PRs with rerun checks no longer show false failure status

Fixes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitHub check evaluation to deduplicate repeated check runs by check name and app, ensuring only the latest run’s result is shown when checks are rerun.

* **Tests**
  * Updated fixtures and added test cases to verify deduplication, latest-run selection, rerun-to-success flows, and separation of runs from different apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->