### PR TITLE
Use custom app:// protocol instead of file:// in Electron

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -33,14 +33,28 @@ function createWindow() {
 
   // Serve dist/ files via the app:// protocol so the renderer has a real
   // origin and can make authenticated GitHub API requests without CORS issues.
-  const distDir = path.join(__dirname, '..', 'dist');
+  const distDir = path.resolve(__dirname, '..', 'dist');
   protocol.handle('app', (request) => {
     const url = new URL(request.url);
-    let filePath = path.join(distDir, decodeURIComponent(url.pathname));
-    // Default to index.html for the root path
-    if (url.pathname === '/' || url.pathname === '') {
-      filePath = path.join(distDir, 'index.html');
+    if (url.host !== 'dashboard') {
+      return new Response('Not found', { status: 404 });
     }
+
+    // Default to index.html for the root path; strip leading slashes so
+    // path.resolve treats the value as relative to distDir.
+    const relativePath =
+      url.pathname === '/' || url.pathname === ''
+        ? 'index.html'
+        : decodeURIComponent(url.pathname).replace(/^\/+/, '');
+
+    // Resolve the candidate path and ensure it stays inside distDir to
+    // prevent path traversal (e.g. app://dashboard/%2e%2e/%2e%2e/etc/passwd).
+    const filePath = path.resolve(distDir, relativePath);
+    const relativeToDist = path.relative(distDir, filePath);
+    if (relativeToDist.startsWith('..') || path.isAbsolute(relativeToDist)) {
+      return new Response('Not found', { status: 404 });
+    }
+
     return net.fetch(pathToFileURL(filePath).toString());
   });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -16,23 +16,11 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-function createWindow() {
-  const win = new BrowserWindow({
-    width: 1200,
-    height: 800,
-    icon: app.isPackaged
-      ? path.join(process.resourcesPath, 'icon.png')
-      : path.join(__dirname, '..', 'build', 'icon.png'),
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
-      webSecurity: true,
-    },
-  });
-
-  // Serve dist/ files via the app:// protocol so the renderer has a real
-  // origin and can make authenticated GitHub API requests without CORS issues.
+// Serve dist/ files via the app:// protocol so the renderer has a real
+// origin and can make authenticated GitHub API requests without CORS issues.
+// Registered once at startup — protocol.handle throws on duplicate registration,
+// and on macOS createWindow() can be called again via the `activate` event.
+function registerAppProtocol() {
   const distDir = path.resolve(__dirname, '..', 'dist');
   protocol.handle('app', (request) => {
     const url = new URL(request.url);
@@ -56,6 +44,22 @@ function createWindow() {
     }
 
     return net.fetch(pathToFileURL(filePath).toString());
+  });
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    icon: app.isPackaged
+      ? path.join(process.resourcesPath, 'icon.png')
+      : path.join(__dirname, '..', 'build', 'icon.png'),
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+    },
   });
 
   // Deny all permission requests (camera, microphone, etc.)
@@ -90,7 +94,10 @@ function createWindow() {
   win.loadURL('app://dashboard/');
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  registerAppProtocol();
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,20 @@
-const { app, BrowserWindow, session, shell } = require('electron');
+const { app, BrowserWindow, net, protocol, session, shell } = require('electron');
 const path = require('path');
+const { pathToFileURL } = require('url');
+
+// Register the custom scheme as privileged so it gets a proper origin
+// and can make CORS requests (file:// has a null origin which blocks fetch).
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+    },
+  },
+]);
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -14,6 +29,19 @@ function createWindow() {
       sandbox: true,
       webSecurity: true,
     },
+  });
+
+  // Serve dist/ files via the app:// protocol so the renderer has a real
+  // origin and can make authenticated GitHub API requests without CORS issues.
+  const distDir = path.join(__dirname, '..', 'dist');
+  protocol.handle('app', (request) => {
+    const url = new URL(request.url);
+    let filePath = path.join(distDir, decodeURIComponent(url.pathname));
+    // Default to index.html for the root path
+    if (url.pathname === '/' || url.pathname === '') {
+      filePath = path.join(distDir, 'index.html');
+    }
+    return net.fetch(pathToFileURL(filePath).toString());
   });
 
   // Deny all permission requests (camera, microphone, etc.)
@@ -45,7 +73,7 @@ function createWindow() {
     openExternalSafe(url);
   });
 
-  win.loadFile(path.join(__dirname, '..', 'dist', 'index.html'));
+  win.loadURL('app://dashboard/');
 }
 
 app.whenReady().then(createWindow);


### PR DESCRIPTION
## Summary

- Registers a custom `app://` protocol scheme as privileged in Electron, replacing `win.loadFile()` with `win.loadURL('app://dashboard/')`
- Gives the renderer a proper origin instead of `file://`'s null origin, which can cause CORS issues with authenticated GitHub API requests depending on Chromium version and OS security settings
- This is the recommended Electron best practice for apps that make cross-origin API calls

## Test plan

- [ ] Run `npm run electron:dev` and verify the app loads and fetches data
- [ ] Verify external links still open in the system browser
- [ ] Verify `npm run dev` (web version) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now serves content via a secure custom app:// scheme for consistent asset and page loading.
* **Refactor**
  * Startup sequence updated to initialize the custom scheme before opening the window for more reliable startup and navigation.
* **Bug Fixes**
  * Added path normalization and traversal protections; missing or out-of-scope resources return clear 404 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->