### PR TITLE
Remove API rate limit display from header

### DIFF
--- a/mobile/src/screens/PRListScreen.tsx
+++ b/mobile/src/screens/PRListScreen.tsx
@@ -18,7 +18,7 @@ import type { DashboardStackParamList } from '../navigation/types';
 type Props = NativeStackScreenProps<DashboardStackParamList, 'PRList'>;
 
 export function PRListScreen({ navigation }: Props) {
-  const { octokit, username, rateLimit } = useApp();
+  const { octokit, username } = useApp();
   const { config, enabledRepos, toggleRepoByName } = useConfigContext();
   const { setUnseenCount } = useBadge();
   const { markSeen, isUnseen } = useLastSeen(asyncStorageAdapter);
@@ -107,9 +107,8 @@ export function PRListScreen({ navigation }: Props) {
       const s = secondsLeft % 60;
       parts.push(`next ${m}:${s.toString().padStart(2, '0')}`);
     }
-    if (rateLimit) parts.push(`API ${rateLimit.remaining}/${rateLimit.limit}`);
     return parts.join(' \u00b7 ');
-  }, [enabledRepos.length, filtered.length, filter, lastRefresh, secondsLeft, rateLimit]);
+  }, [enabledRepos.length, filtered.length, filter, lastRefresh, secondsLeft]);
 
   return (
     <View style={styles.container}>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -220,7 +220,6 @@ export function App() {
         onSignOut={handleSignOut}
         onRefresh={handleRefresh}
         autoRefreshSecondsLeft={autoRefreshSecondsLeft}
-        rateLimit={rateLimit}
       />
       <FilterBar
         active={filter}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { RateLimit } from '../github/client.js';
 import { version } from '../../package.json';
 
 interface HeaderProps {
@@ -12,7 +11,6 @@ interface HeaderProps {
   onSignOut: () => void;
   onRefresh: () => void;
   autoRefreshSecondsLeft: number | null;
-  rateLimit: RateLimit | null;
 }
 
 function formatCountdown(seconds: number): string {
@@ -31,10 +29,7 @@ export function Header({
   onSignOut,
   onRefresh,
   autoRefreshSecondsLeft,
-  rateLimit,
 }: HeaderProps) {
-  const rateLimitWarning = rateLimit && rateLimit.remaining < 500;
-  const rateLimitCritical = rateLimit && rateLimit.remaining < 100;
   return (
     <header className="header">
       <div className="header-left">
@@ -72,14 +67,6 @@ export function Header({
         >
           {loading ? <span className="spinner" /> : '↻'}
         </button>
-        {rateLimit && (
-          <span
-            className={`rate-limit ${rateLimitCritical ? 'rate-limit-critical' : rateLimitWarning ? 'rate-limit-warning' : ''}`}
-            title={`API rate limit: ${rateLimit.remaining}/${rateLimit.limit} remaining. Resets at ${rateLimit.resetAt.toLocaleTimeString()}`}
-          >
-            {rateLimit.remaining}/{rateLimit.limit}
-          </span>
-        )}
         <button className="header-btn" onClick={onOpenRepos} title="Manage repos (c)">
           Repos
         </button>

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -107,22 +107,6 @@
   height: 14px;
 }
 
-/* ── Rate Limit ─────────────────────────────────────────────── */
-.rate-limit {
-  font-size: 12px;
-  color: var(--text-subtle);
-  font-variant-numeric: tabular-nums;
-}
-
-.rate-limit-warning {
-  color: var(--yellow);
-  font-weight: 500;
-}
-
-.rate-limit-critical {
-  color: var(--red);
-  font-weight: 600;
-}
 
 /* ── Spinner ────────────────────────────────────────────────── */
 .spinner {


### PR DESCRIPTION
## Summary
- Remove the API rate limit counter (e.g. "4810/5000") from the web app header and iOS PR list header bar
- Rate limit info remains in the iOS Settings screen for diagnostics
- Clean up associated CSS styles

Closes #106

## Test plan
- [ ] Verify web app header no longer shows rate limit numbers
- [ ] Verify iOS PR list header info no longer shows "API x/y"
- [ ] Verify iOS Settings screen still shows rate limit under Account
- [ ] `npm run build` passes
- [ ] `npm test` passes (210 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Changes**
* Removed API rate limit indicator from the header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->