### PR TITLE
Add "Last Commented By" column

### DIFF
--- a/mobile/src/components/PRListItem.tsx
+++ b/mobile/src/components/PRListItem.tsx
@@ -59,6 +59,12 @@ export function PRListItem({ item, isUnseen, onPress, onLongPress }: PRListItemP
           <Text style={styles.metaSep}> · {timeAgo(item.updatedAt)}</Text>
         </View>
 
+        {item.lastCommenter && (
+          <Text style={styles.lastCommenter} numberOfLines={1}>
+            Last comment by @{item.lastCommenter}
+          </Text>
+        )}
+
         <View style={styles.bottomRow}>
           <View style={styles.badges}>
             {isDraft && (
@@ -250,5 +256,11 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#484f58',
     marginLeft: 'auto',
+  },
+  lastCommenter: {
+    fontSize: 12,
+    color: '#7d8590',
+    marginTop: 3,
+    fontStyle: 'italic',
   },
 });

--- a/shared/columns.ts
+++ b/shared/columns.ts
@@ -19,6 +19,7 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
   { id: 'assignees', label: 'Assignees', className: 'col-assignees', sortKey: 'assignees', defaultVisible: true },
   { id: 'updated', label: 'Updated', className: 'col-updated', sortKey: 'updated', defaultVisible: true },
   { id: 'reviews', label: 'Reviews', className: 'col-reviews', sortKey: 'reviews', defaultVisible: true },
+  { id: 'lastCommenter', label: 'Last Commented By', className: 'col-last-commenter', sortKey: 'lastCommenter', defaultVisible: false },
   { id: 'link', label: 'Link', className: 'col-link', defaultVisible: true },
 ];
 

--- a/shared/github/comments.ts
+++ b/shared/github/comments.ts
@@ -1,0 +1,24 @@
+import type { Octokit } from '@octokit/rest';
+
+/**
+ * Fetch the login of the user who most recently commented on an issue or PR.
+ * Works for both issues and PRs — GitHub's issue-comments endpoint covers
+ * conversation comments on both (PR review comments are a separate endpoint
+ * and are intentionally excluded here).
+ */
+export async function getLastCommenter(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<string | null> {
+  const { data } = await octokit.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 1,
+    sort: 'created',
+    direction: 'desc',
+  });
+  return data[0]?.user?.login ?? null;
+}

--- a/shared/github/issues.ts
+++ b/shared/github/issues.ts
@@ -90,6 +90,7 @@ export async function fetchUserIssues(
               dueOn: item.milestone.due_on ?? null,
             }
           : null,
+        commentsCount: item.comments ?? 0,
       });
     }
 
@@ -162,5 +163,6 @@ export async function fetchAllIssuesForRepo(
           dueOn: item.milestone.due_on ?? null,
         }
       : null,
+    commentsCount: item.comments ?? 0,
   }));
 }

--- a/shared/github/pulls.ts
+++ b/shared/github/pulls.ts
@@ -83,6 +83,7 @@ export async function fetchUserPRs(
             description: l.description ?? undefined,
           };
         }),
+        commentsCount: item.comments ?? 0,
       });
     }
 
@@ -149,6 +150,9 @@ export async function fetchAllPRsForRepo(
         color: l.color ?? '888888',
         description: l.description ?? undefined,
       })),
+      // pulls.list doesn't return a comments count; treat as unknown so the
+      // enricher always attempts a fetch for this code path.
+      commentsCount: undefined,
     };
   });
 }

--- a/shared/hooks/useFilteredItems.ts
+++ b/shared/hooks/useFilteredItems.ts
@@ -7,7 +7,7 @@ import { isMergeReady } from '../utils/mergeReady.js';
 import { STORAGE_KEYS } from '../constants.js';
 
 const FILTER_CYCLE: FilterMode[] = ['all', 'failing', 'needs-review', 'review-requested', 'new-activity', 'merge-ready', 'stale'];
-const SORT_CYCLE: SortMode[] = ['updated', 'created', 'repo', 'status', 'number', 'state', 'title', 'author', 'assignees', 'reviews'];
+const SORT_CYCLE: SortMode[] = ['updated', 'created', 'repo', 'status', 'number', 'state', 'title', 'author', 'assignees', 'reviews', 'lastCommenter'];
 const ITEM_TYPE_CYCLE: ItemTypeFilter[] = ['both', 'prs', 'issues'];
 
 interface UseFilteredItemsOptions {
@@ -198,6 +198,9 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
           cmp = scoreA - scoreB;
           break;
         }
+        case 'lastCommenter':
+          cmp = (a.lastCommenter ?? '').localeCompare(b.lastCommenter ?? '');
+          break;
         default:
           cmp = 0;
       }

--- a/shared/hooks/useGithubData.ts
+++ b/shared/hooks/useGithubData.ts
@@ -1,9 +1,10 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { Octokit } from '@octokit/rest';
-import type { PRItem, DashboardItem, RepoConfig, RepoFetchError, OwnershipFilter } from '../types.js';
+import type { PRItem, IssueItem, DashboardItem, RepoConfig, RepoFetchError, OwnershipFilter } from '../types.js';
 import { fetchUserPRs, fetchAllPRsForRepo } from '../github/pulls.js';
 import { fetchUserIssues, fetchAllIssuesForRepo } from '../github/issues.js';
 import { getCheckStatus, getReviewState, isRequestedReviewer } from '../github/checks.js';
+import { getLastCommenter } from '../github/comments.js';
 import { isAuthError } from '../github/errors.js';
 
 interface UseGithubDataResult {
@@ -85,6 +86,7 @@ export function useGithubData(
     (async () => {
       try {
         let allPRs: PRItem[];
+        let allIssues: IssueItem[] = [];
 
         if (user) {
           // Fetch PRs and issues in parallel, streaming each into the table as it arrives
@@ -105,6 +107,7 @@ export function useGithubData(
           ]);
 
           allPRs = prResult.status === 'fulfilled' ? prResult.value : [];
+          allIssues = issueResult.status === 'fulfilled' ? issueResult.value : [];
 
           if (prResult.status === 'rejected') {
             console.warn('Failed to fetch user PRs:', prResult.reason);
@@ -155,7 +158,7 @@ export function useGithubData(
                 repo: `${repo.owner}/${repo.name}`,
                 message: `Issues: ${e instanceof Error ? e.message : 'Unknown error'}`,
               });
-              return [] as DashboardItem[];
+              return [] as IssueItem[];
             }
           });
 
@@ -176,6 +179,9 @@ export function useGithubData(
           allPRs = prSettled
             .filter((r): r is PromiseFulfilledResult<PRItem[]> => r.status === 'fulfilled')
             .flatMap((r) => r.value);
+          allIssues = issueSettled
+            .filter((r): r is PromiseFulfilledResult<IssueItem[]> => r.status === 'fulfilled')
+            .flatMap((r) => r.value);
 
           if (!cancelled) {
             setFailedRepos(repoErrors);
@@ -184,15 +190,20 @@ export function useGithubData(
 
         if (cancelled) return;
 
-        // Enrich PRs with CI status and reviews, updating each PR as it completes
+        // Enrich PRs with CI status, reviews, and last-commenter, updating each PR as it completes
         const authUser = authUserRef.current;
-        const enrichmentResults = await Promise.allSettled(
+        const prEnrichmentResults = await Promise.allSettled(
           allPRs.map(async (pr) => {
             if (cancelled) return;
             // Only fetch CI/reviews for open PRs (closed/merged don't need it)
             if (pr.state !== 'open') return;
 
-            const [ciResult, reviewResult, requestedResult] = await Promise.allSettled([
+            // Skip the comments fetch when we already know there are none;
+            // commentsCount is undefined for code paths that don't surface it,
+            // so we fetch in that case too.
+            const shouldFetchCommenter = pr.commentsCount !== 0;
+
+            const [ciResult, reviewResult, requestedResult, commenterResult] = await Promise.allSettled([
               getCheckStatus(
                 client,
                 pr.repo.owner,
@@ -203,13 +214,16 @@ export function useGithubData(
               authUser
                 ? isRequestedReviewer(client, pr.repo.owner, pr.repo.name, pr.number, authUser)
                 : Promise.resolve(false),
+              shouldFetchCommenter
+                ? getLastCommenter(client, pr.repo.owner, pr.repo.name, pr.number)
+                : Promise.resolve(null),
             ]);
 
             if (cancelled) return;
 
             // Surface auth failures from enrichment so the outer catch can
             // trigger the re-auth flow instead of silently rendering partial data.
-            for (const r of [ciResult, reviewResult, requestedResult]) {
+            for (const r of [ciResult, reviewResult, requestedResult, commenterResult]) {
               if (r.status === 'rejected' && isAuthError(r.reason)) {
                 throw r.reason;
               }
@@ -229,15 +243,46 @@ export function useGithubData(
                 requestedResult.status === 'fulfilled'
                   ? requestedResult.value
                   : false,
+              lastCommenter:
+                commenterResult.status === 'fulfilled' && commenterResult.value
+                  ? commenterResult.value
+                  : pr.lastCommenter,
             };
 
             setItems((prev) => replaceItem(prev, enriched));
           })
         );
 
+        // Enrich issues with last-commenter only. Skip zero-comment issues to
+        // keep API usage bounded.
+        const issueEnrichmentResults = await Promise.allSettled(
+          allIssues.map(async (issue) => {
+            if (cancelled) return;
+            if (issue.commentsCount === 0) return;
+
+            let commenter: string | null;
+            try {
+              commenter = await getLastCommenter(
+                client,
+                issue.repo.owner,
+                issue.repo.name,
+                issue.number
+              );
+            } catch (e) {
+              if (isAuthError(e)) throw e;
+              return;
+            }
+
+            if (cancelled || !commenter) return;
+
+            const enriched: DashboardItem = { ...issue, lastCommenter: commenter };
+            setItems((prev) => replaceItem(prev, enriched));
+          })
+        );
+
         // Propagate any auth errors that escaped enrichment so the re-auth
         // flow fires instead of silently keeping the stale token.
-        for (const r of enrichmentResults) {
+        for (const r of [...prEnrichmentResults, ...issueEnrichmentResults]) {
           if (r.status === 'rejected' && isAuthError(r.reason)) {
             throw r.reason;
           }

--- a/shared/hooks/useGithubData.ts
+++ b/shared/hooks/useGithubData.ts
@@ -195,25 +195,33 @@ export function useGithubData(
         const prEnrichmentResults = await Promise.allSettled(
           allPRs.map(async (pr) => {
             if (cancelled) return;
-            // Only fetch CI/reviews for open PRs (closed/merged don't need it)
-            if (pr.state !== 'open') return;
 
             // Skip the comments fetch when we already know there are none;
             // commentsCount is undefined for code paths that don't surface it,
             // so we fetch in that case too.
             const shouldFetchCommenter = pr.commentsCount !== 0;
+            // CI/reviews only make sense for open PRs; commenter enrichment
+            // still runs for closed/merged so the column populates everywhere.
+            const isOpen = pr.state === 'open';
+
+            // Nothing to fetch for this PR — skip the work entirely.
+            if (!isOpen && !shouldFetchCommenter) return;
 
             const [ciResult, reviewResult, requestedResult, commenterResult] = await Promise.allSettled([
-              getCheckStatus(
-                client,
-                pr.repo.owner,
-                pr.repo.name,
-                `refs/pull/${pr.number}/head`
-              ),
-              getReviewState(client, pr.repo.owner, pr.repo.name, pr.number),
-              authUser
+              isOpen
+                ? getCheckStatus(
+                    client,
+                    pr.repo.owner,
+                    pr.repo.name,
+                    `refs/pull/${pr.number}/head`
+                  )
+                : Promise.resolve(pr.ciStatus),
+              isOpen
+                ? getReviewState(client, pr.repo.owner, pr.repo.name, pr.number)
+                : Promise.resolve(pr.reviewState),
+              isOpen && authUser
                 ? isRequestedReviewer(client, pr.repo.owner, pr.repo.name, pr.number, authUser)
-                : Promise.resolve(false),
+                : Promise.resolve(pr.isRequestedReviewer),
               shouldFetchCommenter
                 ? getLastCommenter(client, pr.repo.owner, pr.repo.name, pr.number)
                 : Promise.resolve(null),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -16,7 +16,7 @@ export interface Config {
 }
 
 export type CIStatus = 'success' | 'failure' | 'pending' | 'none' | 'mixed';
-export type SortMode = 'updated' | 'created' | 'repo' | 'status' | 'number' | 'state' | 'title' | 'author' | 'assignees' | 'reviews';
+export type SortMode = 'updated' | 'created' | 'repo' | 'status' | 'number' | 'state' | 'title' | 'author' | 'assignees' | 'reviews' | 'lastCommenter';
 export type SortDirection = 'asc' | 'desc';
 export type FilterMode = 'all' | 'failing' | 'needs-review' | 'review-requested' | 'new-activity' | 'merge-ready' | 'stale';
 export type ItemTypeFilter = 'both' | 'prs' | 'issues';
@@ -61,6 +61,8 @@ export interface PRItem {
   isRequestedReviewer: boolean;
   assignees: string[];
   labels: LabelInfo[];
+  commentsCount?: number;
+  lastCommenter?: string;
 }
 
 export interface MilestoneInfo {
@@ -84,6 +86,8 @@ export interface IssueItem {
   labels: LabelInfo[];
   assignees: string[];
   milestone: MilestoneInfo | null;
+  commentsCount?: number;
+  lastCommenter?: string;
 }
 
 export type DashboardItem = PRItem | IssueItem;

--- a/src/components/PRRow.test.tsx
+++ b/src/components/PRRow.test.tsx
@@ -197,4 +197,48 @@ describe('PRRow', () => {
     renderRow(makePR({ isRequestedReviewer: false }));
     expect(screen.queryByTitle('Your review is requested')).not.toBeInTheDocument();
   });
+
+  it('renders the last commenter in the lastCommenter column when present', () => {
+    const onPreview = vi.fn();
+    const onOpen = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <PRRow
+            item={makePR({ lastCommenter: 'alice' })}
+            selected={false}
+            unseen={false}
+            stale={false}
+            onPreview={onPreview}
+            onOpen={onOpen}
+            visibleColumns={DEFAULT_COLUMN_ORDER}
+          />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('@alice')).toBeInTheDocument();
+  });
+
+  it('renders a dash in the lastCommenter column when no commenter', () => {
+    const onPreview = vi.fn();
+    const onOpen = vi.fn();
+    const { container } = render(
+      <table>
+        <tbody>
+          <PRRow
+            item={makePR()}
+            selected={false}
+            unseen={false}
+            stale={false}
+            onPreview={onPreview}
+            onOpen={onOpen}
+            visibleColumns={['lastCommenter']}
+          />
+        </tbody>
+      </table>,
+    );
+    const cell = container.querySelector('.col-last-commenter');
+    expect(cell).not.toBeNull();
+    expect(cell!.textContent).toBe('—');
+  });
 });

--- a/src/components/PRRow.tsx
+++ b/src/components/PRRow.tsx
@@ -119,6 +119,13 @@ export function PRRow({ item, selected, unseen, stale, onPreview, onOpen, onHide
         )}
       </td>
     ),
+    lastCommenter: () => (
+      <td key="lastCommenter" className="col-last-commenter">
+        {item.lastCommenter
+          ? `@${item.lastCommenter}`
+          : <span className="text-muted">&mdash;</span>}
+      </td>
+    ),
     link: () => (
       <td key="link" className="col-link">
         <a

--- a/src/styles/PRTable.css
+++ b/src/styles/PRTable.css
@@ -145,6 +145,15 @@
   white-space: nowrap;
 }
 
+.col-last-commenter {
+  color: var(--text-muted);
+  font-size: 13px;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .col-link {
   width: 40px;
   text-align: center;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -69,7 +69,8 @@ a {
 /* ── Responsive ─────────────────────────────────────────────── */
 @media (max-width: 900px) {
   .col-author,
-  .col-updated {
+  .col-updated,
+  .col-last-commenter {
     display: none;
   }
 }


### PR DESCRIPTION
Fixes #108.

## Summary

- Adds a new optional column, "Last Commented By", showing the GitHub login of the most recent commenter on each PR / issue. Toggle it on via the column-settings dropdown; sorts alphabetically.
- Extends the existing per-item enrichment pass in `useGithubData` with a fourth fetch (`getLastCommenter`) that uses the issue-comments endpoint with `per_page=1, sort=created, direction=desc`. Auth errors propagate the same way as the other enrichers.
- Adds issue enrichment (previously PR-only) so the column populates for issues too. Both paths skip the fetch when the list payload already reports `commentsCount === 0` to keep API usage bounded.
- Mirrors the field on the iOS list as a muted subtitle line ("Last comment by @user") so the mobile and web apps stay in sync per `CLAUDE.md`.
- Adds two unit tests covering the populated and empty cases of the new renderer.

## Test plan

- [x] `npm run build` (tsc + vite) passes
- [x] `npm test` (212/212 passing)
- [ ] Manual: toggle the column in the web UI, confirm `@username` and dash states render, confirm sort works both directions
- [ ] Manual: verify mobile list shows the subtitle on items with comments

## Notes

- `fetchAllPRsForRepo` uses `pulls.list`, which does not return a comments count, so `commentsCount` is left `undefined` there and the enricher falls back to always fetching for that code path. Search-API paths (the common case when a user is set) populate `commentsCount` from the list response and benefit from the skip optimization.
- PR *review comments* (inline code comments) are intentionally excluded — only conversation/issue comments count. This matches the GitHub UI's notion of "last commented."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Last Commented By" column and sorting by last commenter; shows latest commenter metadata for PRs and issues (hidden by default and on small screens).
* **Styles**
  * Added styling and responsive rules to support the new column and hide it on mobile (≤900px).
* **Tests**
  * Added unit tests covering last-commenter display and placeholder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->