### PR TITLE
Skip github-actions[bot] in 'Last Commented By' column

### DIFF
--- a/shared/github/comments.ts
+++ b/shared/github/comments.ts
@@ -1,10 +1,22 @@
 import type { Octokit } from '@octokit/rest';
 
 /**
- * Fetch the login of the user who most recently commented on an issue or PR.
- * Works for both issues and PRs — GitHub's issue-comments endpoint covers
- * conversation comments on both (PR review comments are a separate endpoint
- * and are intentionally excluded here).
+ * Logins to skip when determining the "last commenter" — GitHub Actions
+ * workflows post automated comments on nearly every PR/issue, which drowns
+ * out real human/review activity. Other bots (CodeRabbit, Codecov, etc.)
+ * are intentionally kept since their comments reflect meaningful signal.
+ */
+const EXCLUDED_LOGINS: ReadonlySet<string> = new Set(['github-actions[bot]']);
+
+/**
+ * Fetch the login of the user who most recently commented on an issue or PR,
+ * skipping automated `github-actions[bot]` comments. Works for both issues and
+ * PRs — GitHub's issue-comments endpoint covers conversation comments on both
+ * (PR review comments are a separate endpoint and are intentionally excluded
+ * here).
+ *
+ * Returns `null` if there are no non-excluded commenters among the most recent
+ * 100 comments.
  */
 export async function getLastCommenter(
   octokit: Octokit,
@@ -16,9 +28,15 @@ export async function getLastCommenter(
     owner,
     repo,
     issue_number: issueNumber,
-    per_page: 1,
+    per_page: 100,
     sort: 'created',
     direction: 'desc',
   });
-  return data[0]?.user?.login ?? null;
+  for (const comment of data) {
+    const login = comment.user?.login;
+    if (!login) continue;
+    if (EXCLUDED_LOGINS.has(login)) continue;
+    return login;
+  }
+  return null;
 }

--- a/shared/github/comments.ts
+++ b/shared/github/comments.ts
@@ -9,6 +9,14 @@ import type { Octokit } from '@octokit/rest';
 const EXCLUDED_LOGINS: ReadonlySet<string> = new Set(['github-actions[bot]']);
 
 /**
+ * Maximum comments fetched in a single page when looking for the most recent
+ * non-excluded commenter. 100 is GitHub's per-page cap and gives the
+ * walk-back enough headroom to skip long runs of `github-actions[bot]`
+ * comments on noisy CI repos.
+ */
+export const LAST_COMMENTER_PAGE_SIZE = 100;
+
+/**
  * Fetch the login of the user who most recently commented on an issue or PR,
  * skipping automated `github-actions[bot]` comments. Works for both issues and
  * PRs — GitHub's issue-comments endpoint covers conversation comments on both
@@ -16,7 +24,7 @@ const EXCLUDED_LOGINS: ReadonlySet<string> = new Set(['github-actions[bot]']);
  * here).
  *
  * Returns `null` if there are no non-excluded commenters among the most recent
- * 100 comments.
+ * page of comments.
  */
 export async function getLastCommenter(
   octokit: Octokit,
@@ -28,7 +36,7 @@ export async function getLastCommenter(
     owner,
     repo,
     issue_number: issueNumber,
-    per_page: 100,
+    per_page: LAST_COMMENTER_PAGE_SIZE,
     sort: 'created',
     direction: 'desc',
   });

--- a/src/github/comments.test.ts
+++ b/src/github/comments.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getLastCommenter } from '../../shared/github/comments.js';
+import type { Octokit } from '@octokit/rest';
+
+function mockOctokit(overrides: Record<string, unknown> = {}): Octokit {
+  return overrides as unknown as Octokit;
+}
+
+function comment(login: string) {
+  return { user: { login } };
+}
+
+describe('getLastCommenter', () => {
+  it('returns the most recent non-excluded commenter', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [comment('alice'), comment('bob')],
+        }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
+  });
+
+  it('skips github-actions[bot] and returns the next commenter', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [
+            comment('github-actions[bot]'),
+            comment('github-actions[bot]'),
+            comment('alice'),
+          ],
+        }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
+  });
+
+  it('keeps non-github-actions bots (e.g. CodeRabbit, Codecov)', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [comment('coderabbitai[bot]'), comment('alice')],
+        }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe(
+      'coderabbitai[bot]'
+    );
+  });
+
+  it('returns null when all comments are github-actions[bot]', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [comment('github-actions[bot]'), comment('github-actions[bot]')],
+        }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBeNull();
+  });
+
+  it('returns null when there are no comments', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBeNull();
+  });
+
+  it('skips comments with no user and falls through to the next one', async () => {
+    const octokit = mockOctokit({
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [{ user: null }, comment('alice')],
+        }),
+      },
+    });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
+  });
+
+  it('requests enough comments in descending order to skip noisy bots', async () => {
+    const listComments = vi.fn().mockResolvedValue({ data: [] });
+    const octokit = mockOctokit({ issues: { listComments } });
+
+    await getLastCommenter(octokit, 'acme', 'web', 42);
+
+    expect(listComments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'acme',
+        repo: 'web',
+        issue_number: 42,
+        direction: 'desc',
+      })
+    );
+    const call = listComments.mock.calls[0][0];
+    expect(call.per_page).toBeGreaterThan(1);
+  });
+});

--- a/src/github/comments.test.ts
+++ b/src/github/comments.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getLastCommenter } from '../../shared/github/comments.js';
+import {
+  getLastCommenter,
+  LAST_COMMENTER_PAGE_SIZE,
+} from '../../shared/github/comments.js';
 import type { Octokit } from '@octokit/rest';
 
 function mockOctokit(overrides: Record<string, unknown> = {}): Octokit {
@@ -99,9 +102,8 @@ describe('getLastCommenter', () => {
         repo: 'web',
         issue_number: 42,
         direction: 'desc',
+        per_page: LAST_COMMENTER_PAGE_SIZE,
       })
     );
-    const call = listComments.mock.calls[0][0];
-    expect(call.per_page).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## Summary
- Walk back through the most recent comments and skip `github-actions[bot]` so the "Last Commented By" column surfaces real human/review activity (CodeRabbit, Codecov, etc. still count).
- Fetch up to 100 comments in descending order (was 1) to give the walk-back enough headroom for noisy CI repos.
- Falls back to `null` when only `github-actions` has commented, so the UI renders the existing dash.

Logic lives in `shared/github/comments.ts`, so both the web app and the iOS app pick up the filter automatically — no mobile UI changes needed.

Fixes #110.

## Test plan
- [x] `npm test` — 219 tests pass, including new `src/github/comments.test.ts` cases:
  - most recent non-excluded commenter wins
  - `github-actions[bot]` is skipped, next commenter returned
  - other bots (`coderabbitai[bot]`, etc.) are kept
  - returns `null` when all comments are `github-actions[bot]`
  - returns `null` when there are no comments
  - skips comments with no user and falls through
  - requests enough comments in descending order
- [x] `npm run build` — typecheck + bundle succeed
- [ ] Smoke-check the dashboard against a noisy repo and confirm the column no longer shows `@github-actions[bot]` everywhere
- [ ] Verify iOS app still renders the last commenter correctly (no code change there; shared hook does the filtering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved last-commenter detection to ignore automated bot accounts and to scan up to 100 of the most recent comments (instead of only the newest), yielding more accurate results across recent activity.

* **Tests**
  * Added comprehensive tests covering multiple commenters, bot exclusion, missing user data, empty threads, and behavior when scanning a page of recent comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->