### PR TITLE
Fix Last Commented By column showing first commenter

### DIFF
--- a/shared/github/comments.ts
+++ b/shared/github/comments.ts
@@ -17,14 +17,28 @@ const EXCLUDED_LOGINS: ReadonlySet<string> = new Set(['github-actions[bot]']);
 export const LAST_COMMENTER_PAGE_SIZE = 100;
 
 /**
+ * Extract the page number of the `rel="last"` entry from a GitHub
+ * `Link` response header. Returns `null` when the header is missing or
+ * does not advertise a last page (single-page result).
+ */
+export function parseLastPage(linkHeader: string | undefined): number | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
  * Fetch the login of the user who most recently commented on an issue or PR,
  * skipping automated `github-actions[bot]` comments. Works for both issues and
  * PRs — GitHub's issue-comments endpoint covers conversation comments on both
  * (PR review comments are a separate endpoint and are intentionally excluded
  * here).
  *
- * Returns `null` if there are no non-excluded commenters among the most recent
- * page of comments.
+ * GitHub's per-issue comments endpoint returns comments in ascending
+ * chronological order and ignores `sort`/`direction` params, so we fetch the
+ * last page (via the `Link: rel="last"` header) and walk backwards.
+ *
+ * Returns `null` if there are no non-excluded commenters on the last page.
  */
 export async function getLastCommenter(
   octokit: Octokit,
@@ -32,16 +46,29 @@ export async function getLastCommenter(
   repo: string,
   issueNumber: number
 ): Promise<string | null> {
-  const { data } = await octokit.issues.listComments({
+  const firstPage = await octokit.issues.listComments({
     owner,
     repo,
     issue_number: issueNumber,
     per_page: LAST_COMMENTER_PAGE_SIZE,
-    sort: 'created',
-    direction: 'desc',
   });
-  for (const comment of data) {
-    const login = comment.user?.login;
+
+  const lastPage = parseLastPage(firstPage.headers?.link);
+  const comments =
+    lastPage != null && lastPage > 1
+      ? (
+          await octokit.issues.listComments({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            per_page: LAST_COMMENTER_PAGE_SIZE,
+            page: lastPage,
+          })
+        ).data
+      : firstPage.data;
+
+  for (let i = comments.length - 1; i >= 0; i--) {
+    const login = comments[i].user?.login;
     if (!login) continue;
     if (EXCLUDED_LOGINS.has(login)) continue;
     return login;

--- a/shared/github/comments.ts
+++ b/shared/github/comments.ts
@@ -36,9 +36,12 @@ export function parseLastPage(linkHeader: string | undefined): number | null {
  *
  * GitHub's per-issue comments endpoint returns comments in ascending
  * chronological order and ignores `sort`/`direction` params, so we fetch the
- * last page (via the `Link: rel="last"` header) and walk backwards.
+ * last page (via the `Link: rel="last"` header) and walk backwards. If that
+ * page contains only excluded commenters (e.g. a long `github-actions[bot]`
+ * tail that spans a full page), we step back one page at a time until we
+ * find an eligible login or exhaust the history.
  *
- * Returns `null` if there are no non-excluded commenters on the last page.
+ * Returns `null` if there are no non-excluded commenters on the issue.
  */
 export async function getLastCommenter(
   octokit: Octokit,
@@ -53,25 +56,29 @@ export async function getLastCommenter(
     per_page: LAST_COMMENTER_PAGE_SIZE,
   });
 
-  const lastPage = parseLastPage(firstPage.headers?.link);
-  const comments =
-    lastPage != null && lastPage > 1
-      ? (
-          await octokit.issues.listComments({
-            owner,
-            repo,
-            issue_number: issueNumber,
-            per_page: LAST_COMMENTER_PAGE_SIZE,
-            page: lastPage,
-          })
-        ).data
-      : firstPage.data;
+  const lastPage = parseLastPage(firstPage.headers?.link) ?? 1;
 
-  for (let i = comments.length - 1; i >= 0; i--) {
-    const login = comments[i].user?.login;
-    if (!login) continue;
-    if (EXCLUDED_LOGINS.has(login)) continue;
-    return login;
+  for (let page = lastPage; page >= 1; page--) {
+    const comments =
+      page === 1
+        ? firstPage.data
+        : (
+            await octokit.issues.listComments({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: LAST_COMMENTER_PAGE_SIZE,
+              page,
+            })
+          ).data;
+
+    for (let i = comments.length - 1; i >= 0; i--) {
+      const login = comments[i].user?.login;
+      if (!login) continue;
+      if (EXCLUDED_LOGINS.has(login)) continue;
+      return login;
+    }
   }
+
   return null;
 }

--- a/src/github/comments.test.ts
+++ b/src/github/comments.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   getLastCommenter,
+  parseLastPage,
   LAST_COMMENTER_PAGE_SIZE,
 } from '../../shared/github/comments.js';
 import type { Octokit } from '@octokit/rest';
@@ -13,12 +14,15 @@ function comment(login: string) {
   return { user: { login } };
 }
 
+// The GitHub per-issue comments endpoint returns comments in ascending
+// chronological order (oldest first). Fixtures use that same order so
+// they mirror real API responses.
 describe('getLastCommenter', () => {
-  it('returns the most recent non-excluded commenter', async () => {
+  it('returns the most recent non-excluded commenter (last element)', async () => {
     const octokit = mockOctokit({
       issues: {
         listComments: vi.fn().mockResolvedValue({
-          data: [comment('alice'), comment('bob')],
+          data: [comment('bob'), comment('alice')],
         }),
       },
     });
@@ -26,14 +30,14 @@ describe('getLastCommenter', () => {
     expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
   });
 
-  it('skips github-actions[bot] and returns the next commenter', async () => {
+  it('skips trailing github-actions[bot] comments and returns the next-newest commenter', async () => {
     const octokit = mockOctokit({
       issues: {
         listComments: vi.fn().mockResolvedValue({
           data: [
-            comment('github-actions[bot]'),
-            comment('github-actions[bot]'),
             comment('alice'),
+            comment('github-actions[bot]'),
+            comment('github-actions[bot]'),
           ],
         }),
       },
@@ -46,7 +50,7 @@ describe('getLastCommenter', () => {
     const octokit = mockOctokit({
       issues: {
         listComments: vi.fn().mockResolvedValue({
-          data: [comment('coderabbitai[bot]'), comment('alice')],
+          data: [comment('alice'), comment('coderabbitai[bot]')],
         }),
       },
     });
@@ -82,7 +86,7 @@ describe('getLastCommenter', () => {
     const octokit = mockOctokit({
       issues: {
         listComments: vi.fn().mockResolvedValue({
-          data: [{ user: null }, comment('alice')],
+          data: [comment('alice'), { user: null }],
         }),
       },
     });
@@ -90,20 +94,75 @@ describe('getLastCommenter', () => {
     expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
   });
 
-  it('requests enough comments in descending order to skip noisy bots', async () => {
+  it('requests LAST_COMMENTER_PAGE_SIZE comments without relying on sort/direction', async () => {
     const listComments = vi.fn().mockResolvedValue({ data: [] });
     const octokit = mockOctokit({ issues: { listComments } });
 
     await getLastCommenter(octokit, 'acme', 'web', 42);
 
-    expect(listComments).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: 'acme',
-        repo: 'web',
-        issue_number: 42,
-        direction: 'desc',
-        per_page: LAST_COMMENTER_PAGE_SIZE,
+    expect(listComments).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'web',
+      issue_number: 42,
+      per_page: LAST_COMMENTER_PAGE_SIZE,
+    });
+  });
+
+  it('follows the Link header to the last page when more than one page exists', async () => {
+    const listComments = vi
+      .fn()
+      // First call: page 1 of 3, with a rel="last" link pointing to page 3.
+      .mockResolvedValueOnce({
+        data: [comment('old-one'), comment('old-two')],
+        headers: {
+          link:
+            '<https://api.github.com/repositories/1/issues/1/comments?per_page=100&page=3>; rel="last"',
+        },
       })
-    );
+      // Second call: the last page, whose final comment is the newest.
+      .mockResolvedValueOnce({
+        data: [comment('middle'), comment('newest')],
+      });
+
+    const octokit = mockOctokit({ issues: { listComments } });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('newest');
+    expect(listComments).toHaveBeenNthCalledWith(2, {
+      owner: 'acme',
+      repo: 'web',
+      issue_number: 1,
+      per_page: LAST_COMMENTER_PAGE_SIZE,
+      page: 3,
+    });
+  });
+
+  it('does not fetch a second page when the first page is the last page', async () => {
+    const listComments = vi.fn().mockResolvedValue({
+      data: [comment('alice')],
+      headers: { link: undefined },
+    });
+    const octokit = mockOctokit({ issues: { listComments } });
+
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
+    expect(listComments).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('parseLastPage', () => {
+  it('returns null when the header is missing', () => {
+    expect(parseLastPage(undefined)).toBeNull();
+  });
+
+  it('returns null when the header has no rel="last" entry', () => {
+    const link =
+      '<https://api.github.com/repositories/1/issues/1/comments?per_page=100&page=2>; rel="next"';
+    expect(parseLastPage(link)).toBeNull();
+  });
+
+  it('extracts the last-page number from a full Link header', () => {
+    const link =
+      '<https://api.github.com/repositories/1/issues/1/comments?per_page=100&page=2>; rel="next", ' +
+      '<https://api.github.com/repositories/1/issues/1/comments?per_page=100&page=9>; rel="last"';
+    expect(parseLastPage(link)).toBe(9);
   });
 });

--- a/src/github/comments.test.ts
+++ b/src/github/comments.test.ts
@@ -136,6 +136,34 @@ describe('getLastCommenter', () => {
     });
   });
 
+  it('walks back to earlier pages when the last page has only excluded commenters', async () => {
+    const botTail = Array(LAST_COMMENTER_PAGE_SIZE).fill(
+      comment('github-actions[bot]')
+    );
+    const listComments = vi
+      .fn()
+      // Page 1 of 3: returned by the initial fetch. Ends with the most recent
+      // eligible human commenter before the bot tail.
+      .mockResolvedValueOnce({
+        data: [comment('old-one'), comment('alice')],
+        headers: {
+          link:
+            '<https://api.github.com/repositories/1/issues/1/comments?per_page=100&page=3>; rel="last"',
+        },
+      })
+      // Page 3 (fetched first during walk-back): 100 bot comments, nothing eligible.
+      .mockResolvedValueOnce({ data: botTail })
+      // Page 2 (fetched next): more bot comments.
+      .mockResolvedValueOnce({ data: botTail });
+
+    const octokit = mockOctokit({ issues: { listComments } });
+
+    // Falls back to page 1 (reusing the initial fetch) and returns alice.
+    expect(await getLastCommenter(octokit, 'acme', 'web', 1)).toBe('alice');
+    // Three network calls: initial fetch, page 3, page 2. Page 1 is reused.
+    expect(listComments).toHaveBeenCalledTimes(3);
+  });
+
   it('does not fetch a second page when the first page is the last page', async () => {
     const listComments = vi.fn().mockResolvedValue({
       data: [comment('alice')],


### PR DESCRIPTION
## Summary

- GitHub's per-issue comments endpoint ignores `sort`/`direction` params and always returns comments oldest-first, so the previous walk-from-the-front logic was effectively returning the **first** commenter.
- Fetch the last page (via the `Link: rel="last"` header) and walk backwards to find the most recent non-excluded login. Most PRs resolve in a single API call; only threads with >100 comments trigger a second fetch.
- Export `parseLastPage` and cover it + the pagination path with new unit tests. Existing fixtures were rewritten to reflect the real oldest-first API order.

Fixes #112

## Test plan

- [x] `npm test` (224 passing)
- [x] `npm run build`
- [ ] Verify against WordPress/gutenberg#41169 in the running app — expected: column shows `@adamsilverstein`, not `@gaambo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identification of the most recent commenter by correctly handling paginated GitHub comments, scanning pages in newest-first order and skipping bot/excluded commenters when present.
* **Tests**
  * Added and updated tests to cover pagination via Link headers, oldest-first storage ordering, and bot-skipping behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->