### PR TITLE
Add 'My replies' filter to hide rows where I commented last

### DIFF
--- a/mobile/src/components/FilterBar.tsx
+++ b/mobile/src/components/FilterBar.tsx
@@ -59,6 +59,9 @@ interface FilterBarProps {
   // Labels
   labelFilterCount: number;
   onLabelFilterPress: () => void;
+  // Hide my replies
+  hideMyReplies?: boolean;
+  onToggleHideMyReplies?: () => void;
   // Hidden repos
   hiddenRepos: RepoConfig[];
   onRestoreRepo: (owner: string, name: string) => void;
@@ -71,6 +74,7 @@ export function FilterBar({
   itemTypeFilter, onItemTypeChange,
   prStateFilters, onTogglePRState,
   labelFilterCount, onLabelFilterPress,
+  hideMyReplies, onToggleHideMyReplies,
   hiddenRepos, onRestoreRepo,
 }: FilterBarProps) {
   return (
@@ -142,6 +146,16 @@ export function FilterBar({
             Labels{labelFilterCount > 0 ? ` (${labelFilterCount})` : ''}
           </Text>
         </TouchableOpacity>
+        {onToggleHideMyReplies && (
+          <TouchableOpacity
+            style={[styles.chip, hideMyReplies && styles.chipActive]}
+            onPress={onToggleHideMyReplies}
+          >
+            <Text style={[styles.chipText, hideMyReplies && styles.chipTextActive]}>
+              {hideMyReplies ? 'Hide my replies' : 'Show my replies'}
+            </Text>
+          </TouchableOpacity>
+        )}
         {hiddenRepos.length > 0 && hiddenRepos.map((repo) => (
           <TouchableOpacity
             key={`${repo.owner}/${repo.name}`}

--- a/mobile/src/screens/PRListScreen.tsx
+++ b/mobile/src/screens/PRListScreen.tsx
@@ -41,6 +41,7 @@ export function PRListScreen({ navigation }: Props) {
     itemTypeFilter, setItemTypeFilter,
     prStateFilters, togglePRStateFilter,
     labelFilters, toggleLabelFilter, clearLabelFilters, availableLabels,
+    hideMyReplies, toggleHideMyReplies,
   } = useFilteredItems({
     items,
     defaultFilter: config.defaults.filter,
@@ -48,6 +49,7 @@ export function PRListScreen({ navigation }: Props) {
     isUnseen,
     staleDays: config.defaults.staleDays,
     storage: asyncStorageAdapter,
+    authUser: username,
   });
 
   const { secondsLeft, reset: resetAutoRefresh } = useAutoRefresh({
@@ -142,6 +144,8 @@ export function PRListScreen({ navigation }: Props) {
         onTogglePRState={togglePRStateFilter}
         labelFilterCount={labelFilters.size}
         onLabelFilterPress={() => setLabelModalVisible(true)}
+        hideMyReplies={hideMyReplies}
+        onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
         hiddenRepos={hiddenRepos}
         onRestoreRepo={toggleRepoByName}
       />

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -8,4 +8,5 @@ export const STORAGE_KEYS = {
   DETAIL_CACHE: 'gh-dashboard-detail-cache',
   COLUMN_SETTINGS: 'gh-dashboard-column-settings',
   LABEL_FILTERS: 'gh-dashboard-label-filters',
+  HIDE_MY_REPLIES: 'gh-dashboard-hide-my-replies',
 } as const;

--- a/shared/hooks/useFilteredItems.ts
+++ b/shared/hooks/useFilteredItems.ts
@@ -17,9 +17,14 @@ interface UseFilteredItemsOptions {
   isUnseen: (item: DashboardItem) => boolean;
   staleDays: number;
   storage: StorageAdapter;
+  /**
+   * Authenticated GitHub login. Enables the "hide my replies" filter —
+   * when null the filter is inert even if the toggle is on.
+   */
+  authUser?: string | null;
 }
 
-export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, staleDays, storage }: UseFilteredItemsOptions) {
+export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, staleDays, storage, authUser }: UseFilteredItemsOptions) {
   const [filter, setFilter] = useState<FilterMode>(defaultFilter);
   const [sort, setSort] = useState<SortMode>(defaultSort);
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
@@ -28,6 +33,7 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
   const [cursorIndex, setCursorIndex] = useState(0);
   const [prStateFilters, setPRStateFilters] = useState<Set<PRStateFilterKey>>(new Set(['draft', 'open']));
   const [labelFilters, setLabelFilters] = useState<Set<string>>(new Set());
+  const [hideMyReplies, setHideMyReplies] = useState(false);
 
   // Load persisted filters from storage on mount
   useEffect(() => {
@@ -39,6 +45,9 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
           setLabelFilters(new Set(parsed.filter((s) => typeof s === 'string')));
         }
       } catch { /* ignore */ }
+    });
+    storage.getItem(STORAGE_KEYS.HIDE_MY_REPLIES).then((stored) => {
+      if (stored === 'true') setHideMyReplies(true);
     });
     storage.getItem(STORAGE_KEYS.PR_STATE_FILTERS).then((stored) => {
       if (!stored) return;
@@ -63,6 +72,16 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
   useEffect(() => {
     storage.setItem(STORAGE_KEYS.LABEL_FILTERS, JSON.stringify([...labelFilters])).catch(() => {});
   }, [labelFilters, storage]);
+
+  // Persist hide-my-replies toggle
+  useEffect(() => {
+    storage.setItem(STORAGE_KEYS.HIDE_MY_REPLIES, hideMyReplies ? 'true' : 'false').catch(() => {});
+  }, [hideMyReplies, storage]);
+
+  const toggleHideMyReplies = useCallback(() => {
+    setHideMyReplies((prev) => !prev);
+    setCursorIndex(0);
+  }, []);
 
   const toggleLabelFilter = useCallback((label: string) => {
     setLabelFilters((prev) => {
@@ -112,6 +131,14 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
       result = result.filter((item) =>
         item.labels.some((l) => labelFilters.has(l.name))
       );
+    }
+
+    // Hide items where I was the last commenter — useful for finding threads
+    // waiting on someone else's reply. Rows with no lastCommenter (zero
+    // comments, or enrichment not yet resolved) are kept so we don't hide
+    // genuinely unanswered items.
+    if (hideMyReplies && authUser) {
+      result = result.filter((item) => item.lastCommenter !== authUser);
     }
 
     if (filter === 'failing') {
@@ -208,7 +235,7 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
     });
 
     return result;
-  }, [items, filter, sort, sortDirection, searchQuery, itemTypeFilter, prStateFilters, labelFilters, isUnseen, staleDays]);
+  }, [items, filter, sort, sortDirection, searchQuery, itemTypeFilter, prStateFilters, labelFilters, hideMyReplies, authUser, isUnseen, staleDays]);
 
   // Clamp cursor when filtered list shrinks
   useEffect(() => {
@@ -296,6 +323,8 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
     toggleLabelFilter,
     clearLabelFilters,
     availableLabels,
+    hideMyReplies,
+    toggleHideMyReplies,
     moveCursor,
     cycleFilter,
     cycleSort,

--- a/shared/hooks/useFilteredItems.ts
+++ b/shared/hooks/useFilteredItems.ts
@@ -34,6 +34,7 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
   const [prStateFilters, setPRStateFilters] = useState<Set<PRStateFilterKey>>(new Set(['draft', 'open']));
   const [labelFilters, setLabelFilters] = useState<Set<string>>(new Set());
   const [hideMyReplies, setHideMyReplies] = useState(false);
+  const [hideMyRepliesLoaded, setHideMyRepliesLoaded] = useState(false);
 
   // Load persisted filters from storage on mount
   useEffect(() => {
@@ -46,9 +47,13 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
         }
       } catch { /* ignore */ }
     });
-    storage.getItem(STORAGE_KEYS.HIDE_MY_REPLIES).then((stored) => {
-      if (stored === 'true') setHideMyReplies(true);
-    });
+    storage
+      .getItem(STORAGE_KEYS.HIDE_MY_REPLIES)
+      .then((stored) => {
+        if (stored === 'true') setHideMyReplies(true);
+      })
+      .catch(() => { /* ignore */ })
+      .finally(() => setHideMyRepliesLoaded(true));
     storage.getItem(STORAGE_KEYS.PR_STATE_FILTERS).then((stored) => {
       if (!stored) return;
       try {
@@ -73,10 +78,13 @@ export function useFilteredItems({ items, defaultFilter, defaultSort, isUnseen, 
     storage.setItem(STORAGE_KEYS.LABEL_FILTERS, JSON.stringify([...labelFilters])).catch(() => {});
   }, [labelFilters, storage]);
 
-  // Persist hide-my-replies toggle
+  // Persist hide-my-replies toggle, but only after the initial async load
+  // completes — otherwise the default `false` would clobber a persisted `true`
+  // on async storage adapters (AsyncStorage on mobile) before the loader reads.
   useEffect(() => {
+    if (!hideMyRepliesLoaded) return;
     storage.setItem(STORAGE_KEYS.HIDE_MY_REPLIES, hideMyReplies ? 'true' : 'false').catch(() => {});
-  }, [hideMyReplies, storage]);
+  }, [hideMyReplies, hideMyRepliesLoaded, storage]);
 
   const toggleHideMyReplies = useCallback(() => {
     setHideMyReplies((prev) => !prev);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -102,6 +102,7 @@ export function App() {
     itemTypeFilter, setItemTypeFilter, cursorIndex, setCursorIndex,
     prStateFilters, togglePRStateFilter,
     labelFilters, toggleLabelFilter, clearLabelFilters, availableLabels,
+    hideMyReplies, toggleHideMyReplies,
     moveCursor, cycleFilter, cycleSort,
     handleSetFilter, handleSetSort, cycleItemType,
   } = useFilteredItems({
@@ -110,6 +111,7 @@ export function App() {
     defaultSort: config.defaults.sort,
     isUnseen,
     staleDays: config.defaults.staleDays,
+    authUser: username,
   });
 
   const { secondsLeft: autoRefreshSecondsLeft, reset: resetAutoRefresh } = useAutoRefresh({
@@ -240,6 +242,8 @@ export function App() {
         onToggleLabel={toggleLabelFilter}
         onClearLabels={clearLabelFilters}
         availableLabels={availableLabels}
+        hideMyReplies={hideMyReplies}
+        onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
         milestoneGrouping={milestoneGrouping}
         onToggleMilestoneGrouping={toggleMilestoneGrouping}
       />

--- a/src/components/FilterBar.test.tsx
+++ b/src/components/FilterBar.test.tsx
@@ -113,3 +113,28 @@ describe('FilterBar search', () => {
     expect(screen.getByPlaceholderText('Search… ( / )')).toBeInTheDocument();
   });
 });
+
+describe('FilterBar hide my replies toggle', () => {
+  it('hides the toggle when no handler is provided (no auth user)', () => {
+    renderFilterBar();
+    expect(screen.queryByText('My replies')).not.toBeInTheDocument();
+  });
+
+  it('renders the toggle with Shown label when inactive', () => {
+    renderFilterBar({ onToggleHideMyReplies: vi.fn(), hideMyReplies: false });
+    expect(screen.getByText('My replies')).toBeInTheDocument();
+    expect(screen.getByText('Shown')).toBeInTheDocument();
+  });
+
+  it('renders the toggle with Hidden label when active', () => {
+    renderFilterBar({ onToggleHideMyReplies: vi.fn(), hideMyReplies: true });
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('calls onToggleHideMyReplies when clicked', async () => {
+    const onToggleHideMyReplies = vi.fn();
+    renderFilterBar({ onToggleHideMyReplies });
+    await userEvent.click(screen.getByText('My replies'));
+    expect(onToggleHideMyReplies).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -52,11 +52,14 @@ interface FilterBarProps {
   onToggleLabel: (label: string) => void;
   onClearLabels: () => void;
   availableLabels: LabelInfo[];
+  hideMyReplies?: boolean;
+  /** When provided, renders the "Hide my replies" toggle. Omit to hide the control (e.g. before auth user is known). */
+  onToggleHideMyReplies?: () => void;
   milestoneGrouping?: boolean;
   onToggleMilestoneGrouping?: () => void;
 }
 
-export function FilterBar({ active, onFilter, ownershipFilter, onSetOwnership, username, searchQuery, onSearchChange, searchInputRef, itemTypeFilter, onSetItemType, hiddenRepos, onRestoreRepo, prStateFilters, onTogglePRState, labelFilters, onToggleLabel, onClearLabels, availableLabels, milestoneGrouping, onToggleMilestoneGrouping }: FilterBarProps) {
+export function FilterBar({ active, onFilter, ownershipFilter, onSetOwnership, username, searchQuery, onSearchChange, searchInputRef, itemTypeFilter, onSetItemType, hiddenRepos, onRestoreRepo, prStateFilters, onTogglePRState, labelFilters, onToggleLabel, onClearLabels, availableLabels, hideMyReplies, onToggleHideMyReplies, milestoneGrouping, onToggleMilestoneGrouping }: FilterBarProps) {
   const [showHiddenDropdown, setShowHiddenDropdown] = useState(false);
   const [showLabelDropdown, setShowLabelDropdown] = useState(false);
   const hiddenCount = hiddenRepos?.length ?? 0;
@@ -170,6 +173,16 @@ export function FilterBar({ active, onFilter, ownershipFilter, onSetOwnership, u
             </div>
           )}
         </div>
+      )}
+      {onToggleHideMyReplies && (
+        <button
+          className={`filter-dropdown-trigger ${hideMyReplies ? 'filter-active' : ''}`}
+          onClick={onToggleHideMyReplies}
+          title="Hide items where I was the last commenter"
+        >
+          <span className="filter-dropdown-category">My replies</span>
+          <span className="filter-dropdown-value">{hideMyReplies ? 'Hidden' : 'Shown'}</span>
+        </button>
       )}
       {onToggleMilestoneGrouping && (
         <button

--- a/src/hooks/useFilteredItems.ts
+++ b/src/hooks/useFilteredItems.ts
@@ -10,6 +10,7 @@ interface UseFilteredItemsOptions {
   defaultSort: SortMode;
   isUnseen: (item: DashboardItem) => boolean;
   staleDays: number;
+  authUser?: string | null;
 }
 
 export function useFilteredItems(options: UseFilteredItemsOptions) {


### PR DESCRIPTION
## Summary

- Adds a **My replies** toggle to the filter bar on web and iOS. When enabled, items whose `lastCommenter` equals the authenticated GitHub user are hidden — useful for surfacing threads waiting on someone else's response.
- Items with no `lastCommenter` (zero comments, or enrichment still pending) stay visible so we don't hide genuinely unanswered items.
- Preference is persisted via the shared `StorageAdapter` under a new `HIDE_MY_REPLIES` key, so the toggle sticks across reloads on both platforms.
- The control is hidden until the authenticated user is known, so the filter is never a no-op.

Closes #113

## Notes

- The underlying data is only meaningful once #112 lands — before that fix, `lastCommenter` is actually the **first** commenter, so the filter will hide the wrong rows. Once #112 is merged, this filter does the right thing automatically.
- Pre-existing Octokit type mismatches in `mobile/` remain (unrelated to this PR).

## Test plan

- [x] `npm test` (223 passing; +4 new FilterBar toggle tests)
- [x] `npm run build`
- [ ] Verify in the web app: toggle hides rows where `@adamsilverstein` is the last commenter.
- [ ] Verify in the iOS Simulator: chip appears in the filter row and persists across reloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My replies" toggle to the filter bar so authenticated users can hide or show their own replies; preference is persisted and affects the displayed list.

* **Tests**
  * Added tests covering the "My replies" toggle visibility, labels, and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->