### PR TITLE
Default to GitHub OAuth Device Flow with PAT fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ release/
 *.tsbuildinfo
 .DS_Store
 test-results/
+.env
+.env.local
+.env.*.local

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A lightweight, keyboard-driven GitHub PR dashboard built with React and TypeScri
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) 20 or later (see `.nvmrc`)
-- A GitHub Personal Access Token (see [Creating a GitHub PAT](#creating-a-github-pat) below)
+- A way to authenticate to GitHub:
+  - **OAuth** (recommended for the desktop and iOS apps) — see [Connecting to GitHub](#connecting-to-github).
+  - **Personal Access Token** — fallback for the browser build, or any time OAuth is unavailable.
 
 ### Installation
 
@@ -40,9 +42,34 @@ npm run build    # Type-checks and builds to dist/
 npm run preview  # Preview the production build locally
 ```
 
-## Creating a GitHub PAT
+## Connecting to GitHub
 
-The dashboard uses a **Personal Access Token** to read pull request data from the GitHub API.
+The dashboard supports two authentication methods. **OAuth via the GitHub Device Flow is the default** when it's available; a **Personal Access Token** is always offered as a fallback.
+
+| Build target | OAuth available? | Why |
+|--------------|------------------|-----|
+| Electron desktop | ✅ Yes | Main process proxies the OAuth POSTs (no browser CORS). |
+| iOS / mobile | ✅ Yes | Native `fetch` has no CORS restriction. |
+| Browser (`npm run dev`, `vite preview`) | ❌ No | GitHub's OAuth endpoints don't return CORS headers; falls back to PAT. |
+
+### Option A — OAuth Device Flow (recommended)
+
+OAuth requires a one-time setup by the project owner: register a GitHub OAuth App and ship its **public** `client_id` with the build. Users then sign in by entering a short code on github.com — no token copy/paste, no `client_secret` required.
+
+1. Register a new OAuth App at [github.com/settings/developers](https://github.com/settings/developers).
+   - **Application name:** Git Dashboard
+   - **Homepage URL:** anything (e.g. your fork's URL)
+   - **Authorization callback URL:** `https://github.com` (Device Flow doesn't use it; GitHub still requires the field)
+   - **Enable Device Flow:** ✅ (under app settings)
+2. Copy the **Client ID** (the `client_secret` is **not** needed).
+3. Provide the client ID to your build:
+   - **Web / Electron** — set `VITE_GITHUB_OAUTH_CLIENT_ID=<client_id>` in your shell or in a `.env` file before `npm run build` or `npm run electron:dev`.
+   - **Mobile** — set `EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID=<client_id>` (e.g. via `mobile/.env` or [EAS Secrets](https://docs.expo.dev/build-reference/variables/)) before `npx expo run:ios` or an EAS build.
+4. Launch the app and click **Connect with GitHub** on the sign-in screen.
+
+If the client ID is unset (or you're running in a plain browser), the sign-in screen automatically falls back to PAT entry.
+
+### Option B — Personal Access Token (fallback)
 
 1. Go to [github.com/settings/tokens](https://github.com/settings/tokens)
 2. Click **Generate new token** (classic)
@@ -52,6 +79,8 @@ The dashboard uses a **Personal Access Token** to read pull request data from th
 6. Paste the token into the dashboard's setup screen and click **Save & Continue**
 
 > **Tip:** You can also use a [fine-grained token](https://github.com/settings/tokens?type=beta) scoped to specific repositories with **Pull requests** (read) and **Checks** (read) permissions.
+
+The active connection method (OAuth or PAT) is shown next to the **Sign out** button on the desktop/web header and in the **Account** section of the iOS Settings tab.
 
 ## Keyboard Shortcuts
 
@@ -78,7 +107,7 @@ All settings are stored in the browser's `localStorage` — nothing is sent to a
 
 | Key | Description |
 |-----|-------------|
-| `gh-dashboard-token` | Your GitHub Personal Access Token |
+| `gh-dashboard-token` | Your GitHub access token (OAuth `gho_…` or PAT `ghp_…`/`github_pat_…`). |
 | `gh-dashboard-config` | JSON object containing repos and display preferences |
 
 The config object has the following shape:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 npm run dev
 ```
 
-The dev server starts at **http://localhost:5173**. On first visit you'll be prompted to enter your GitHub token.
+The dev server starts at **http://localhost:5173**. On first visit you'll be prompted to sign in — the dashboard uses GitHub OAuth (Device Flow) by default where available, and falls back to a Personal Access Token otherwise. See [Connecting to GitHub](#connecting-to-github) for setup details.
 
 ### Production Build
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,49 @@
-const { app, BrowserWindow, net, protocol, session, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, net, protocol, session, shell } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
+
+// GitHub OAuth Device Flow endpoints. The renderer cannot call these directly
+// because GitHub does not return CORS headers for them, so the main process
+// proxies the requests via Node's `net.fetch`.
+const ALLOWED_OAUTH_URLS = new Set([
+  'https://github.com/login/device/code',
+  'https://github.com/login/oauth/access_token',
+]);
+
+function registerOAuthBridge() {
+  ipcMain.handle('oauth:postForm', async (_event, url, body) => {
+    if (typeof url !== 'string' || !ALLOWED_OAUTH_URLS.has(url)) {
+      throw new Error(`Refusing OAuth request to disallowed URL: ${url}`);
+    }
+    if (!body || typeof body !== 'object') {
+      throw new Error('OAuth bridge requires a body object');
+    }
+
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      if (typeof key !== 'string' || typeof value !== 'string') {
+        throw new Error('OAuth body entries must be strings');
+      }
+      params.append(key, value);
+    }
+
+    const response = await net.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: params.toString(),
+    });
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`OAuth endpoint returned non-JSON response (status ${response.status})`);
+    }
+  });
+}
 
 // Register the custom scheme as privileged so it gets a proper origin
 // and can make CORS requests (file:// has a null origin which blocks fetch).
@@ -59,6 +102,7 @@ function createWindow() {
       contextIsolation: true,
       sandbox: true,
       webSecurity: true,
+      preload: path.join(__dirname, 'preload.cjs'),
     },
   });
 
@@ -96,6 +140,7 @@ function createWindow() {
 
 app.whenReady().then(() => {
   registerAppProtocol();
+  registerOAuthBridge();
   createWindow();
 });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -27,20 +27,29 @@ function registerOAuthBridge() {
       params.append(key, value);
     }
 
-    const response = await net.fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Accept: 'application/json',
-      },
-      body: params.toString(),
-    });
-
-    const text = await response.text();
+    // Bound the request so a hung network doesn't leave the Device Flow UI
+    // wedged in a pending state. Electron's `net.fetch` honors AbortSignal.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
     try {
-      return JSON.parse(text);
-    } catch {
-      throw new Error(`OAuth endpoint returned non-JSON response (status ${response.status})`);
+      const response = await net.fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: params.toString(),
+        signal: controller.signal,
+      });
+
+      const text = await response.text();
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`OAuth endpoint returned non-JSON response (status ${response.status})`);
+      }
+    } finally {
+      clearTimeout(timeout);
     }
   });
 }

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -19,7 +19,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   clipboard: {
     writeText(text) {
-      clipboard.writeText(String(text));
+      if (typeof text !== 'string') {
+        throw new TypeError('clipboard.writeText expects a string');
+      }
+      clipboard.writeText(text);
     },
   },
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,7 +5,7 @@
  * main process validates every URL before making a request. The renderer
  * cannot drive arbitrary network calls through this bridge.
  */
-const { contextBridge, ipcRenderer } = require('electron');
+const { clipboard, contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   oauthDeviceFlow: {
@@ -15,6 +15,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
      */
     postForm(url, body) {
       return ipcRenderer.invoke('oauth:postForm', url, body);
+    },
+  },
+  clipboard: {
+    writeText(text) {
+      clipboard.writeText(String(text));
     },
   },
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,20 @@
+/**
+ * Electron preload — exposes a small, audited surface to the renderer.
+ *
+ * Only methods needed for the GitHub OAuth Device Flow are exposed; the
+ * main process validates every URL before making a request. The renderer
+ * cannot drive arbitrary network calls through this bridge.
+ */
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  oauthDeviceFlow: {
+    /**
+     * POST a form-encoded body to a GitHub OAuth endpoint and return the JSON response.
+     * The main process restricts allowed URLs to GitHub's device/access-token endpoints.
+     */
+    postForm(url, body) {
+      return ipcRenderer.invoke('oauth:postForm', url, body);
+    },
+  },
+});

--- a/mobile/src/auth/oauthConfig.ts
+++ b/mobile/src/auth/oauthConfig.ts
@@ -1,0 +1,26 @@
+import type { DeviceFlowTransport } from '../../../shared/auth/transport';
+import { nativeOAuthTransport } from './transport';
+
+/**
+ * GitHub OAuth App `client_id`. Set `EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID`
+ * (e.g. via `.env` or EAS Secrets) to enable OAuth login. When unset, the
+ * mobile app falls back to PAT entry only.
+ */
+export const OAUTH_CLIENT_ID: string =
+  (process.env.EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID as string | undefined) ?? '';
+
+export interface OAuthAvailability {
+  available: boolean;
+  reason?: string;
+  transport?: DeviceFlowTransport;
+}
+
+export function getOAuthAvailability(): OAuthAvailability {
+  if (!OAUTH_CLIENT_ID) {
+    return {
+      available: false,
+      reason: 'OAuth is not configured for this build (EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID is unset).',
+    };
+  }
+  return { available: true, transport: nativeOAuthTransport };
+}

--- a/mobile/src/auth/transport.ts
+++ b/mobile/src/auth/transport.ts
@@ -1,0 +1,31 @@
+import type { DeviceFlowTransport } from '../../../shared/auth/transport';
+
+/**
+ * React Native transport for the GitHub Device Flow.
+ * Native fetch has no CORS restriction, so it can call the OAuth endpoints
+ * directly without a proxy.
+ */
+export const nativeOAuthTransport: DeviceFlowTransport = {
+  async postForm(url, body) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body)) {
+      params.append(key, value);
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: params.toString(),
+    });
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`OAuth endpoint returned non-JSON response (status ${response.status})`);
+    }
+  },
+};

--- a/mobile/src/auth/useDeviceFlow.ts
+++ b/mobile/src/auth/useDeviceFlow.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Linking } from 'react-native';
+import {
+  requestDeviceCode,
+  pollAccessToken,
+  DeviceFlowAbortedError,
+  type DeviceCodeResponse,
+} from '../../../shared/auth/deviceFlow';
+import { OAUTH_CLIENT_ID, getOAuthAvailability } from './oauthConfig';
+
+export type DeviceFlowStatus = 'idle' | 'requesting' | 'awaiting' | 'success' | 'error';
+
+export interface DeviceFlowState {
+  status: DeviceFlowStatus;
+  device: DeviceCodeResponse | null;
+  token: string | null;
+  error: string | null;
+}
+
+const INITIAL_STATE: DeviceFlowState = {
+  status: 'idle',
+  device: null,
+  token: null,
+  error: null,
+};
+
+export function useDeviceFlow() {
+  const [state, setState] = useState<DeviceFlowState>(INITIAL_STATE);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState(INITIAL_STATE);
+  }, []);
+
+  const start = useCallback(async () => {
+    const availability = getOAuthAvailability();
+    if (!availability.available || !availability.transport) {
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: availability.reason ?? 'OAuth is unavailable.',
+      });
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState({ status: 'requesting', device: null, token: null, error: null });
+
+    let device: DeviceCodeResponse;
+    try {
+      device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
+    } catch (err) {
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: err instanceof Error ? err.message : 'Failed to request device code',
+      });
+      return;
+    }
+
+    setState({ status: 'awaiting', device, token: null, error: null });
+
+    Linking.openURL(device.verification_uri).catch(() => {
+      // The verification URL is also displayed on screen; user can open it manually.
+    });
+
+    try {
+      const token = await pollAccessToken(availability.transport, OAUTH_CLIENT_ID, device.device_code, {
+        intervalSeconds: device.interval,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      setState({ status: 'success', device, token, error: null });
+    } catch (err) {
+      if (err instanceof DeviceFlowAbortedError) return;
+      setState({
+        status: 'error',
+        device,
+        token: null,
+        error: err instanceof Error ? err.message : 'OAuth failed',
+      });
+    }
+  }, []);
+
+  return { state, start, cancel };
+}

--- a/mobile/src/auth/useDeviceFlow.ts
+++ b/mobile/src/auth/useDeviceFlow.ts
@@ -1,99 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { Linking } from 'react-native';
-import {
-  requestDeviceCode,
-  pollAccessToken,
-  DeviceFlowAbortedError,
-  type DeviceCodeResponse,
-} from '../../../shared/auth/deviceFlow';
+import { useDeviceFlow as useSharedDeviceFlow } from '../../../shared/auth/useDeviceFlow';
 import { OAUTH_CLIENT_ID, getOAuthAvailability } from './oauthConfig';
 
-export type DeviceFlowStatus = 'idle' | 'requesting' | 'awaiting' | 'success' | 'error';
+export type { DeviceFlowState, DeviceFlowStatus } from '../../../shared/auth/useDeviceFlow';
 
-export interface DeviceFlowState {
-  status: DeviceFlowStatus;
-  device: DeviceCodeResponse | null;
-  token: string | null;
-  error: string | null;
+/** Open a URL via the OS browser; failures are swallowed (URL is on screen). */
+function openInSystemBrowser(url: string): void {
+  Linking.openURL(url).catch(() => {
+    // The verification URL is also displayed on screen; user can open it manually.
+  });
 }
 
-const INITIAL_STATE: DeviceFlowState = {
-  status: 'idle',
-  device: null,
-  token: null,
-  error: null,
-};
-
+/** Mobile wrapper around the shared Device Flow state machine. */
 export function useDeviceFlow() {
-  const [state, setState] = useState<DeviceFlowState>(INITIAL_STATE);
-  const abortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => () => abortRef.current?.abort(), []);
-
-  const cancel = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setState(INITIAL_STATE);
-  }, []);
-
-  const start = useCallback(async () => {
-    const availability = getOAuthAvailability();
-    if (!availability.available || !availability.transport) {
-      setState({
-        status: 'error',
-        device: null,
-        token: null,
-        error: availability.reason ?? 'OAuth is unavailable.',
-      });
-      return;
-    }
-
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setState({ status: 'requesting', device: null, token: null, error: null });
-
-    let device: DeviceCodeResponse;
-    try {
-      device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      setState({
-        status: 'error',
-        device: null,
-        token: null,
-        error: err instanceof Error ? err.message : 'Failed to request device code',
-      });
-      return;
-    }
-
-    // Bail if cancel() (or a newer start()) aborted while the request was in flight.
-    if (controller.signal.aborted) return;
-
-    setState({ status: 'awaiting', device, token: null, error: null });
-
-    Linking.openURL(device.verification_uri).catch(() => {
-      // The verification URL is also displayed on screen; user can open it manually.
-    });
-
-    try {
-      const token = await pollAccessToken(availability.transport, OAUTH_CLIENT_ID, device.device_code, {
-        intervalSeconds: device.interval,
-        signal: controller.signal,
-      });
-      if (controller.signal.aborted) return;
-      setState({ status: 'success', device, token, error: null });
-    } catch (err) {
-      if (err instanceof DeviceFlowAbortedError) return;
-      setState({
-        status: 'error',
-        device,
-        token: null,
-        error: err instanceof Error ? err.message : 'OAuth failed',
-      });
-    }
-  }, []);
-
-  return { state, start, cancel };
+  return useSharedDeviceFlow({
+    getAvailability: getOAuthAvailability,
+    clientId: OAUTH_CLIENT_ID,
+    openVerificationUrl: openInSystemBrowser,
+  });
 }

--- a/mobile/src/auth/useDeviceFlow.ts
+++ b/mobile/src/auth/useDeviceFlow.ts
@@ -58,6 +58,7 @@ export function useDeviceFlow() {
     try {
       device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setState({
         status: 'error',
         device: null,
@@ -66,6 +67,9 @@ export function useDeviceFlow() {
       });
       return;
     }
+
+    // Bail if cancel() (or a newer start()) aborted while the request was in flight.
+    if (controller.signal.aborted) return;
 
     setState({ status: 'awaiting', device, token: null, error: null });
 

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -10,9 +10,11 @@ import {
 } from 'react-native';
 import { useApp } from '../context/AppContext';
 import { useConfigContext } from '../context/ConfigContext';
+import { authMethodLabel, getAuthMethod } from '../../../shared/auth/method';
 
 export function SettingsScreen() {
-  const { username, rateLimit, signOut } = useApp();
+  const { token, username, rateLimit, signOut } = useApp();
+  const authMethod = getAuthMethod(token);
   const { config, addRepo, removeRepo, toggleRepo, updateDefaults } = useConfigContext();
   const [repoInput, setRepoInput] = useState('');
 
@@ -50,6 +52,12 @@ export function SettingsScreen() {
           <Text style={styles.label}>Signed in as</Text>
           <Text style={styles.value}>{username ?? '...'}</Text>
         </View>
+        {authMethod && (
+          <View style={styles.row}>
+            <Text style={styles.label}>Connection</Text>
+            <Text style={styles.value}>{authMethodLabel(authMethod)}</Text>
+          </View>
+        )}
         {rateLimit && (
           <View style={styles.row}>
             <Text style={styles.label}>API Rate Limit</Text>

--- a/mobile/src/screens/TokenSetupScreen.tsx
+++ b/mobile/src/screens/TokenSetupScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -9,32 +9,51 @@ import {
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
+  ScrollView,
 } from 'react-native';
 import { useApp } from '../context/AppContext';
+import { useDeviceFlow } from '../auth/useDeviceFlow';
+import { getOAuthAvailability } from '../auth/oauthConfig';
+
+type Mode = 'oauth' | 'pat';
 
 export function TokenSetupScreen() {
   const { saveToken } = useApp();
+  const oauthAvailability = useMemo(() => getOAuthAvailability(), []);
+  const [mode, setMode] = useState<Mode>(oauthAvailability.available ? 'oauth' : 'pat');
+
+  const { state: oauthState, start: startOAuth, cancel: cancelOAuth } = useDeviceFlow();
+
   const [input, setInput] = useState('');
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [patError, setPatError] = useState<string | null>(null);
   const [showToken, setShowToken] = useState(false);
 
-  const handleSave = async () => {
+  // Persist OAuth token as soon as polling succeeds.
+  useEffect(() => {
+    if (oauthState.status === 'success' && oauthState.token) {
+      saveToken(oauthState.token).catch(() => {
+        // Saving failure surfaces in the device-flow error path next time.
+      });
+    }
+  }, [oauthState.status, oauthState.token, saveToken]);
+
+  const handleSavePat = async () => {
     const trimmed = input.trim();
     if (!trimmed) {
-      setError('Please enter a token');
+      setPatError('Please enter a token');
       return;
     }
     if (!trimmed.startsWith('ghp_') && !trimmed.startsWith('github_pat_')) {
-      setError('Token should start with ghp_ or github_pat_');
+      setPatError('Token should start with ghp_ or github_pat_');
       return;
     }
     setSaving(true);
-    setError(null);
+    setPatError(null);
     try {
       await saveToken(trimmed);
     } catch {
-      setError('Failed to save token');
+      setPatError('Failed to save token');
       setSaving(false);
     }
   };
@@ -44,59 +63,179 @@ export function TokenSetupScreen() {
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <View style={styles.content}>
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
         <Text style={styles.title}>Git Dashboard</Text>
         <Text style={styles.subtitle}>GitHub PR Dashboard for iOS</Text>
 
-        <View style={styles.card}>
-          <Text style={styles.label}>GitHub Personal Access Token</Text>
-          <View style={styles.inputRow}>
-            <TextInput
-              style={styles.input}
-              value={input}
-              onChangeText={setInput}
-              placeholder="ghp_xxxxxxxxxxxx"
-              placeholderTextColor="#666"
-              secureTextEntry={!showToken}
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoComplete="off"
-            />
-            <TouchableOpacity
-              style={styles.toggleButton}
-              onPress={() => setShowToken((prev) => !prev)}
-            >
-              <Text style={styles.toggleText}>{showToken ? 'Hide' : 'Show'}</Text>
-            </TouchableOpacity>
-          </View>
-          {error && <Text style={styles.error}>{error}</Text>}
-
-          <TouchableOpacity
-            style={[styles.button, !input.trim() && styles.buttonDisabled]}
-            onPress={handleSave}
-            disabled={saving || !input.trim()}
-          >
-            {saving ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text style={styles.buttonText}>Save Token</Text>
-            )}
-          </TouchableOpacity>
-        </View>
-
-        <TouchableOpacity
-          style={styles.link}
-          onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo&description=Git+Dashboard+iOS')}
-        >
-          <Text style={styles.linkText}>Create a new token on GitHub</Text>
-        </TouchableOpacity>
-
-        <Text style={styles.hint}>
-          Requires a Classic token with <Text style={styles.code}>repo</Text> scope,{' '}
-          or a Fine-grained token with Pull requests (read) and Checks (read).
-        </Text>
-      </View>
+        {mode === 'oauth' && oauthAvailability.available ? (
+          <OAuthCard
+            state={oauthState}
+            onStart={startOAuth}
+            onCancel={cancelOAuth}
+            onUsePat={() => {
+              cancelOAuth();
+              setMode('pat');
+            }}
+          />
+        ) : (
+          <PatCard
+            input={input}
+            showToken={showToken}
+            saving={saving}
+            error={patError}
+            onChangeInput={(v) => {
+              setInput(v);
+              if (patError) setPatError(null);
+            }}
+            onToggleShow={() => setShowToken((p) => !p)}
+            onSubmit={handleSavePat}
+            oauthReason={oauthAvailability.available ? null : oauthAvailability.reason ?? null}
+            onUseOAuth={oauthAvailability.available ? () => setMode('oauth') : undefined}
+          />
+        )}
+      </ScrollView>
     </KeyboardAvoidingView>
+  );
+}
+
+function OAuthCard({
+  state,
+  onStart,
+  onCancel,
+  onUsePat,
+}: {
+  state: ReturnType<typeof useDeviceFlow>['state'];
+  onStart: () => void;
+  onCancel: () => void;
+  onUsePat: () => void;
+}) {
+  if (state.status === 'awaiting' && state.device) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.label}>Authorize on GitHub</Text>
+        <Text style={styles.helper}>
+          Open the URL below and enter this code, then approve the dashboard.
+        </Text>
+        <View style={styles.codeBox}>
+          <Text style={styles.codeText} selectable>
+            {state.device.user_code}
+          </Text>
+        </View>
+        <TouchableOpacity
+          onPress={() => Linking.openURL(state.device!.verification_uri).catch(() => {})}
+        >
+          <Text style={styles.linkText}>{state.device.verification_uri}</Text>
+        </TouchableOpacity>
+        <Text style={styles.waiting}>Waiting for approval…</Text>
+        <ActivityIndicator color="#58a6ff" style={{ marginVertical: 8 }} />
+        <TouchableOpacity style={[styles.button, styles.secondaryButton]} onPress={onCancel}>
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.linkButton} onPress={onUsePat}>
+          <Text style={styles.linkText}>Use a Personal Access Token instead</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.label}>Sign in with GitHub</Text>
+      <Text style={styles.helper}>
+        Connect securely without copying a token. We'll open GitHub to confirm.
+      </Text>
+      {state.status === 'error' && state.error && <Text style={styles.error}>{state.error}</Text>}
+      <TouchableOpacity
+        style={[styles.button, state.status === 'requesting' && styles.buttonDisabled]}
+        onPress={onStart}
+        disabled={state.status === 'requesting'}
+      >
+        {state.status === 'requesting' ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.buttonText}>Connect with GitHub</Text>
+        )}
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.linkButton} onPress={onUsePat}>
+        <Text style={styles.linkText}>Use a Personal Access Token instead</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function PatCard({
+  input,
+  showToken,
+  saving,
+  error,
+  onChangeInput,
+  onToggleShow,
+  onSubmit,
+  oauthReason,
+  onUseOAuth,
+}: {
+  input: string;
+  showToken: boolean;
+  saving: boolean;
+  error: string | null;
+  onChangeInput: (v: string) => void;
+  onToggleShow: () => void;
+  onSubmit: () => void;
+  oauthReason: string | null;
+  onUseOAuth?: () => void;
+}) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.label}>GitHub Personal Access Token</Text>
+      {oauthReason && <Text style={styles.helper}>{oauthReason}</Text>}
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          value={input}
+          onChangeText={onChangeInput}
+          placeholder="ghp_xxxxxxxxxxxx"
+          placeholderTextColor="#666"
+          secureTextEntry={!showToken}
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoComplete="off"
+        />
+        <TouchableOpacity style={styles.toggleButton} onPress={onToggleShow}>
+          <Text style={styles.toggleText}>{showToken ? 'Hide' : 'Show'}</Text>
+        </TouchableOpacity>
+      </View>
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      <TouchableOpacity
+        style={[styles.button, !input.trim() && styles.buttonDisabled]}
+        onPress={onSubmit}
+        disabled={saving || !input.trim()}
+      >
+        {saving ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.buttonText}>Save Token</Text>
+        )}
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.linkButton}
+        onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo&description=Git+Dashboard+iOS')}
+      >
+        <Text style={styles.linkText}>Create a new token on GitHub</Text>
+      </TouchableOpacity>
+
+      <Text style={styles.hint}>
+        Requires a Classic token with <Text style={styles.code}>repo</Text> scope,{' '}
+        or a Fine-grained token with Pull requests (read) and Checks (read).
+      </Text>
+
+      {onUseOAuth && (
+        <TouchableOpacity style={styles.linkButton} onPress={onUseOAuth}>
+          <Text style={styles.linkText}>Sign in with GitHub OAuth instead</Text>
+        </TouchableOpacity>
+      )}
+    </View>
   );
 }
 
@@ -106,9 +245,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#0d1117',
   },
   content: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: 'center',
     paddingHorizontal: 24,
+    paddingVertical: 24,
   },
   title: {
     fontSize: 32,
@@ -135,6 +275,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#e6edf3',
     marginBottom: 8,
+  },
+  helper: {
+    fontSize: 13,
+    color: '#7d8590',
+    marginBottom: 12,
+    lineHeight: 18,
   },
   inputRow: {
     flexDirection: 'row',
@@ -171,6 +317,17 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 14,
     alignItems: 'center',
+    marginTop: 8,
+  },
+  secondaryButton: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#30363d',
+  },
+  secondaryButtonText: {
+    color: '#e6edf3',
+    fontSize: 16,
+    fontWeight: '500',
   },
   buttonDisabled: {
     opacity: 0.5,
@@ -180,13 +337,14 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  link: {
-    marginTop: 20,
+  linkButton: {
+    marginTop: 16,
     alignItems: 'center',
   },
   linkText: {
     color: '#58a6ff',
     fontSize: 14,
+    textAlign: 'center',
   },
   hint: {
     color: '#7d8590',
@@ -198,5 +356,28 @@ const styles = StyleSheet.create({
   code: {
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     color: '#e6edf3',
+  },
+  codeBox: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#30363d',
+    borderRadius: 8,
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginVertical: 12,
+  },
+  codeText: {
+    color: '#58a6ff',
+    fontSize: 28,
+    fontWeight: '700',
+    letterSpacing: 4,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  waiting: {
+    color: '#7d8590',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 8,
   },
 });

--- a/mobile/src/screens/TokenSetupScreen.tsx
+++ b/mobile/src/screens/TokenSetupScreen.tsx
@@ -28,15 +28,32 @@ export function TokenSetupScreen() {
   const [saving, setSaving] = useState(false);
   const [patError, setPatError] = useState<string | null>(null);
   const [showToken, setShowToken] = useState(false);
+  const [oauthSaveError, setOAuthSaveError] = useState<string | null>(null);
 
-  // Persist OAuth token as soon as polling succeeds.
+  // Persist OAuth token as soon as polling succeeds. SecureStore writes can
+  // fail (Keychain permission issues, etc.); surface the error so the user
+  // can retry instead of being stranded on a "success" screen.
   useEffect(() => {
-    if (oauthState.status === 'success' && oauthState.token) {
-      saveToken(oauthState.token).catch(() => {
-        // Saving failure surfaces in the device-flow error path next time.
-      });
-    }
+    if (oauthState.status !== 'success' || !oauthState.token) return;
+    setOAuthSaveError(null);
+    saveToken(oauthState.token).catch((err) => {
+      console.warn('Failed to save OAuth token:', err);
+      setOAuthSaveError(
+        err instanceof Error ? err.message : 'Could not save the token to secure storage.'
+      );
+    });
   }, [oauthState.status, oauthState.token, saveToken]);
+
+  const retryOAuthSave = () => {
+    if (!oauthState.token) return;
+    setOAuthSaveError(null);
+    saveToken(oauthState.token).catch((err) => {
+      console.warn('Failed to save OAuth token:', err);
+      setOAuthSaveError(
+        err instanceof Error ? err.message : 'Could not save the token to secure storage.'
+      );
+    });
+  };
 
   const handleSavePat = async () => {
     const trimmed = input.trim();
@@ -70,10 +87,13 @@ export function TokenSetupScreen() {
         {mode === 'oauth' && oauthAvailability.available ? (
           <OAuthCard
             state={oauthState}
+            saveError={oauthSaveError}
+            onRetrySave={retryOAuthSave}
             onStart={startOAuth}
             onCancel={cancelOAuth}
             onUsePat={() => {
               cancelOAuth();
+              setOAuthSaveError(null);
               setMode('pat');
             }}
           />
@@ -100,15 +120,38 @@ export function TokenSetupScreen() {
 
 function OAuthCard({
   state,
+  saveError,
+  onRetrySave,
   onStart,
   onCancel,
   onUsePat,
 }: {
   state: ReturnType<typeof useDeviceFlow>['state'];
+  saveError: string | null;
+  onRetrySave: () => void;
   onStart: () => void;
   onCancel: () => void;
   onUsePat: () => void;
 }) {
+  if (state.status === 'success' && saveError) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.label}>Sign-in succeeded, but saving failed</Text>
+        <Text style={styles.error}>{saveError}</Text>
+        <Text style={styles.helper}>
+          Your GitHub authorization was approved, but the token couldn't be written to secure
+          storage on this device. Try again, or fall back to a Personal Access Token.
+        </Text>
+        <TouchableOpacity style={styles.button} onPress={onRetrySave}>
+          <Text style={styles.buttonText}>Retry save</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.linkButton} onPress={onUsePat}>
+          <Text style={styles.linkText}>Use a Personal Access Token instead</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   if (state.status === 'awaiting' && state.device) {
     return (
       <View style={styles.card}>

--- a/shared/auth/deviceFlow.test.ts
+++ b/shared/auth/deviceFlow.test.ts
@@ -165,6 +165,20 @@ describe('pollAccessToken', () => {
     ).rejects.toBeInstanceOf(DeviceFlowAbortedError);
   });
 
+  it('rejects with DeviceFlowAbortedError when an already-aborted signal is passed to the real sleep', async () => {
+    const transport = makeTransport([]);
+    const controller = new AbortController();
+    controller.abort();
+    // Use the real defaultSleep (no `sleep` override) to exercise the
+    // listener-then-check ordering inside it.
+    await expect(
+      pollAccessToken(transport, 'cid', 'dc', {
+        intervalSeconds: 0,
+        signal: controller.signal,
+      })
+    ).rejects.toBeInstanceOf(DeviceFlowAbortedError);
+  });
+
   it('throws when GitHub returns an unknown error code', async () => {
     const transport = makeTransport([
       { error: 'invalid_grant', error_description: 'bad device code' },

--- a/shared/auth/deviceFlow.test.ts
+++ b/shared/auth/deviceFlow.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  requestDeviceCode,
+  pollAccessToken,
+  DeviceFlowError,
+  DeviceFlowAbortedError,
+  GITHUB_DEVICE_CODE_URL,
+  GITHUB_ACCESS_TOKEN_URL,
+} from './deviceFlow.js';
+import type { DeviceFlowTransport } from './transport.js';
+
+function makeTransport(
+  responses: Array<Record<string, unknown>>
+): DeviceFlowTransport & { calls: Array<{ url: string; body: Record<string, string> }> } {
+  const calls: Array<{ url: string; body: Record<string, string> }> = [];
+  let idx = 0;
+  return {
+    calls,
+    postForm: async (url, body) => {
+      calls.push({ url, body });
+      const response = responses[idx];
+      idx += 1;
+      if (!response) throw new Error('Transport called more times than scripted');
+      return response;
+    },
+  };
+}
+
+describe('requestDeviceCode', () => {
+  it('posts to the device code endpoint with client_id and scope', async () => {
+    const transport = makeTransport([
+      {
+        device_code: 'dc',
+        user_code: 'WDJB-MJHT',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      },
+    ]);
+
+    const result = await requestDeviceCode(transport, 'client123', 'repo');
+
+    expect(transport.calls[0]).toEqual({
+      url: GITHUB_DEVICE_CODE_URL,
+      body: { client_id: 'client123', scope: 'repo' },
+    });
+    expect(result.user_code).toBe('WDJB-MJHT');
+    expect(result.interval).toBe(5);
+  });
+
+  it('uses the default scope when none is provided', async () => {
+    const transport = makeTransport([
+      {
+        device_code: 'dc',
+        user_code: 'CODE',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      },
+    ]);
+    await requestDeviceCode(transport, 'client123');
+    expect(transport.calls[0].body.scope).toBe('repo');
+  });
+
+  it('throws DeviceFlowError when GitHub returns an error payload', async () => {
+    const transport = makeTransport([
+      { error: 'unauthorized_client', error_description: 'OAuth app suspended' },
+    ]);
+    await expect(requestDeviceCode(transport, 'client123')).rejects.toMatchObject({
+      message: 'OAuth app suspended',
+      code: 'unauthorized_client',
+    });
+  });
+
+  it('throws when the response is missing required fields', async () => {
+    const transport = makeTransport([{ device_code: 'dc' }]);
+    await expect(requestDeviceCode(transport, 'client123')).rejects.toBeInstanceOf(DeviceFlowError);
+  });
+});
+
+describe('pollAccessToken', () => {
+  it('returns the access_token on the first successful poll', async () => {
+    const transport = makeTransport([{ access_token: 'gho_abc' }]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const token = await pollAccessToken(transport, 'client123', 'device-code', {
+      intervalSeconds: 5,
+      sleep,
+    });
+
+    expect(token).toBe('gho_abc');
+    expect(sleep).toHaveBeenCalledWith(5000, undefined);
+    expect(transport.calls[0]).toEqual({
+      url: GITHUB_ACCESS_TOKEN_URL,
+      body: {
+        client_id: 'client123',
+        device_code: 'device-code',
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      },
+    });
+  });
+
+  it('keeps polling on authorization_pending', async () => {
+    const transport = makeTransport([
+      { error: 'authorization_pending' },
+      { error: 'authorization_pending' },
+      { access_token: 'gho_xyz' },
+    ]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const token = await pollAccessToken(transport, 'cid', 'dc', {
+      intervalSeconds: 5,
+      sleep,
+    });
+
+    expect(token).toBe('gho_xyz');
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 5000, undefined);
+    expect(sleep).toHaveBeenNthCalledWith(2, 5000, undefined);
+  });
+
+  it('increases interval by 5 seconds when GitHub returns slow_down', async () => {
+    const transport = makeTransport([
+      { error: 'slow_down' },
+      { access_token: 'gho_ok' },
+    ]);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await pollAccessToken(transport, 'cid', 'dc', { intervalSeconds: 5, sleep });
+
+    expect(sleep).toHaveBeenNthCalledWith(1, 5000, undefined);
+    expect(sleep).toHaveBeenNthCalledWith(2, 10000, undefined);
+  });
+
+  it('throws DeviceFlowError on expired_token', async () => {
+    const transport = makeTransport([{ error: 'expired_token' }]);
+    await expect(
+      pollAccessToken(transport, 'cid', 'dc', {
+        intervalSeconds: 1,
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+    ).rejects.toMatchObject({ code: 'expired_token' });
+  });
+
+  it('throws DeviceFlowError on access_denied', async () => {
+    const transport = makeTransport([{ error: 'access_denied' }]);
+    await expect(
+      pollAccessToken(transport, 'cid', 'dc', {
+        intervalSeconds: 1,
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+    ).rejects.toMatchObject({ code: 'access_denied' });
+  });
+
+  it('throws DeviceFlowAbortedError when the signal is aborted before sleep', async () => {
+    const transport = makeTransport([]);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      pollAccessToken(transport, 'cid', 'dc', {
+        intervalSeconds: 1,
+        signal: controller.signal,
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+    ).rejects.toBeInstanceOf(DeviceFlowAbortedError);
+  });
+
+  it('throws when GitHub returns an unknown error code', async () => {
+    const transport = makeTransport([
+      { error: 'invalid_grant', error_description: 'bad device code' },
+    ]);
+    await expect(
+      pollAccessToken(transport, 'cid', 'dc', {
+        intervalSeconds: 1,
+        sleep: vi.fn().mockResolvedValue(undefined),
+      })
+    ).rejects.toMatchObject({ code: 'invalid_grant', message: 'bad device code' });
+  });
+});

--- a/shared/auth/deviceFlow.ts
+++ b/shared/auth/deviceFlow.ts
@@ -3,7 +3,12 @@ import type { DeviceFlowTransport } from './transport.js';
 export const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code';
 export const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 
-/** Default scope for the dashboard — read access to PRs and check status. */
+/**
+ * Default scope. The `repo` scope is required to read PRs, commits, and check
+ * status from private repositories — there is no narrower OAuth scope that
+ * grants private-repo PR read access. Note that `repo` also confers write
+ * access; the dashboard never uses it, but token holders should be aware.
+ */
 export const DEFAULT_OAUTH_SCOPE = 'repo';
 
 export interface DeviceCodeResponse {
@@ -131,10 +136,6 @@ export async function pollAccessToken(
 
 function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new DeviceFlowAbortedError());
-      return;
-    }
     const timer = setTimeout(() => {
       cleanup();
       resolve();
@@ -143,10 +144,16 @@ function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
       cleanup();
       reject(new DeviceFlowAbortedError());
     };
-    signal?.addEventListener('abort', onAbort);
     function cleanup() {
       clearTimeout(timer);
       signal?.removeEventListener('abort', onAbort);
+    }
+    signal?.addEventListener('abort', onAbort);
+    // Check after registering so a signal that was already aborted is caught
+    // (the abort event would have fired before we listened for it).
+    if (signal?.aborted) {
+      cleanup();
+      reject(new DeviceFlowAbortedError());
     }
   });
 }

--- a/shared/auth/deviceFlow.ts
+++ b/shared/auth/deviceFlow.ts
@@ -1,0 +1,152 @@
+import type { DeviceFlowTransport } from './transport.js';
+
+export const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code';
+export const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+
+/** Default scope for the dashboard — read access to PRs and check status. */
+export const DEFAULT_OAUTH_SCOPE = 'repo';
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  /** Seconds until the device_code expires. */
+  expires_in: number;
+  /** Seconds the client must wait between polls. */
+  interval: number;
+}
+
+export class DeviceFlowError extends Error {
+  constructor(message: string, public readonly code?: string) {
+    super(message);
+    this.name = 'DeviceFlowError';
+  }
+}
+
+/** Raised when polling is aborted by the caller. */
+export class DeviceFlowAbortedError extends DeviceFlowError {
+  constructor() {
+    super('Device flow aborted', 'aborted');
+    this.name = 'DeviceFlowAbortedError';
+  }
+}
+
+export async function requestDeviceCode(
+  transport: DeviceFlowTransport,
+  clientId: string,
+  scope: string = DEFAULT_OAUTH_SCOPE
+): Promise<DeviceCodeResponse> {
+  const result = await transport.postForm(GITHUB_DEVICE_CODE_URL, {
+    client_id: clientId,
+    scope,
+  });
+
+  if (typeof result.error === 'string') {
+    throw new DeviceFlowError(
+      typeof result.error_description === 'string' ? result.error_description : result.error,
+      result.error
+    );
+  }
+
+  if (
+    typeof result.device_code !== 'string' ||
+    typeof result.user_code !== 'string' ||
+    typeof result.verification_uri !== 'string' ||
+    typeof result.expires_in !== 'number' ||
+    typeof result.interval !== 'number'
+  ) {
+    throw new DeviceFlowError('Malformed device code response from GitHub');
+  }
+
+  return {
+    device_code: result.device_code,
+    user_code: result.user_code,
+    verification_uri: result.verification_uri,
+    expires_in: result.expires_in,
+    interval: result.interval,
+  };
+}
+
+export interface PollOptions {
+  /** Initial poll interval in seconds, supplied by GitHub. */
+  intervalSeconds: number;
+  /** Caller-controlled cancellation. */
+  signal?: AbortSignal;
+  /** Test seam — defaults to setTimeout-based wait. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+/**
+ * Poll GitHub for the access token until the user authorizes (or denies / lets it expire).
+ *
+ * Implements the wait-and-back-off rules from the OAuth Device Flow spec:
+ *   - `authorization_pending` → continue polling at the current interval.
+ *   - `slow_down` → bump the interval by 5 seconds (per the spec).
+ *   - `expired_token` / `access_denied` → terminal failure.
+ */
+export async function pollAccessToken(
+  transport: DeviceFlowTransport,
+  clientId: string,
+  deviceCode: string,
+  options: PollOptions
+): Promise<string> {
+  const { signal, sleep = defaultSleep } = options;
+  let intervalMs = options.intervalSeconds * 1000;
+
+  while (true) {
+    if (signal?.aborted) throw new DeviceFlowAbortedError();
+    await sleep(intervalMs, signal);
+
+    const result = await transport.postForm(GITHUB_ACCESS_TOKEN_URL, {
+      client_id: clientId,
+      device_code: deviceCode,
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    });
+
+    if (typeof result.access_token === 'string' && result.access_token.length > 0) {
+      return result.access_token;
+    }
+
+    const code = typeof result.error === 'string' ? result.error : 'unknown';
+    switch (code) {
+      case 'authorization_pending':
+        continue;
+      case 'slow_down':
+        intervalMs += 5000;
+        continue;
+      case 'expired_token':
+        throw new DeviceFlowError('Login code expired before you finished signing in.', code);
+      case 'access_denied':
+        throw new DeviceFlowError('Authorization was declined.', code);
+      default:
+        throw new DeviceFlowError(
+          typeof result.error_description === 'string'
+            ? result.error_description
+            : `OAuth error: ${code}`,
+          code
+        );
+    }
+  }
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DeviceFlowAbortedError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(new DeviceFlowAbortedError());
+    };
+    signal?.addEventListener('abort', onAbort);
+    function cleanup() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    }
+  });
+}

--- a/shared/auth/deviceFlow.ts
+++ b/shared/auth/deviceFlow.ts
@@ -101,6 +101,9 @@ export async function pollAccessToken(
   while (true) {
     if (signal?.aborted) throw new DeviceFlowAbortedError();
     await sleep(intervalMs, signal);
+    // Re-check after the sleep so a cancel that landed during the wait
+    // doesn't trigger one more access-token POST before we notice.
+    if (signal?.aborted) throw new DeviceFlowAbortedError();
 
     const result = await transport.postForm(GITHUB_ACCESS_TOKEN_URL, {
       client_id: clientId,

--- a/shared/auth/method.test.ts
+++ b/shared/auth/method.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getAuthMethod, authMethodLabel } from './method.js';
+
+describe('getAuthMethod', () => {
+  it('returns null when no token is provided', () => {
+    expect(getAuthMethod(null)).toBe(null);
+    expect(getAuthMethod('')).toBe(null);
+  });
+
+  it('classifies gho_ tokens as oauth', () => {
+    expect(getAuthMethod('gho_abc123')).toBe('oauth');
+  });
+
+  it('classifies ghp_ classic PATs as pat', () => {
+    expect(getAuthMethod('ghp_xyz789')).toBe('pat');
+  });
+
+  it('classifies github_pat_ fine-grained PATs as pat', () => {
+    expect(getAuthMethod('github_pat_111111')).toBe('pat');
+  });
+
+  it('falls back to pat for unknown prefixes', () => {
+    expect(getAuthMethod('legacy-token')).toBe('pat');
+  });
+});
+
+describe('authMethodLabel', () => {
+  it('returns human-readable labels', () => {
+    expect(authMethodLabel('oauth')).toBe('OAuth');
+    expect(authMethodLabel('pat')).toBe('Personal Access Token');
+  });
+});

--- a/shared/auth/method.ts
+++ b/shared/auth/method.ts
@@ -1,0 +1,17 @@
+export type AuthMethod = 'oauth' | 'pat';
+
+/**
+ * Derive the connection method from the stored token.
+ *
+ * GitHub OAuth Device Flow tokens are prefixed with `gho_`.
+ * Personal Access Tokens use `ghp_` (classic) or `github_pat_` (fine-grained).
+ * Anything else is treated as PAT for display purposes.
+ */
+export function getAuthMethod(token: string | null): AuthMethod | null {
+  if (!token) return null;
+  return token.startsWith('gho_') ? 'oauth' : 'pat';
+}
+
+export function authMethodLabel(method: AuthMethod): string {
+  return method === 'oauth' ? 'OAuth' : 'Personal Access Token';
+}

--- a/shared/auth/transport.ts
+++ b/shared/auth/transport.ts
@@ -1,0 +1,14 @@
+/**
+ * Platform-agnostic transport for the GitHub Device Flow.
+ *
+ * Browsers cannot call GitHub's OAuth endpoints directly because GitHub does
+ * not return CORS headers for `/login/device/code` and `/login/oauth/access_token`.
+ * Each platform supplies a transport that bypasses that restriction:
+ *
+ *   - Electron: IPC to the main process, which uses Node's HTTP stack.
+ *   - React Native: native `fetch` (no browser CORS).
+ *   - Pure web: no transport — OAuth is unavailable, fall back to PAT.
+ */
+export interface DeviceFlowTransport {
+  postForm(url: string, body: Record<string, string>): Promise<Record<string, unknown>>;
+}

--- a/shared/auth/useDeviceFlow.ts
+++ b/shared/auth/useDeviceFlow.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  DeviceFlowAbortedError,
+  pollAccessToken,
+  requestDeviceCode,
+  type DeviceCodeResponse,
+} from './deviceFlow.js';
+import type { DeviceFlowTransport } from './transport.js';
+
+export type DeviceFlowStatus = 'idle' | 'requesting' | 'awaiting' | 'success' | 'error';
+
+export interface DeviceFlowState {
+  status: DeviceFlowStatus;
+  device: DeviceCodeResponse | null;
+  token: string | null;
+  error: string | null;
+}
+
+export interface DeviceFlowAvailability {
+  available: boolean;
+  reason?: string;
+  transport?: DeviceFlowTransport;
+}
+
+export interface UseDeviceFlowOptions {
+  /** Called at the start of each flow to resolve transport + client availability. */
+  getAvailability: () => DeviceFlowAvailability;
+  /** OAuth App client_id. */
+  clientId: string;
+  /**
+   * Open the verification URL in the platform's system browser. Errors are
+   * ignored — the URL is displayed on screen so the user can copy it manually.
+   * Implementations may be sync (web `window.open`) or fire-and-forget async
+   * (React Native `Linking.openURL`).
+   */
+  openVerificationUrl: (url: string) => void;
+}
+
+const INITIAL_STATE: DeviceFlowState = {
+  status: 'idle',
+  device: null,
+  token: null,
+  error: null,
+};
+
+/**
+ * Platform-agnostic GitHub Device Flow hook.
+ *
+ * Platform wrappers (`src/auth/useDeviceFlow.ts`, `mobile/src/auth/useDeviceFlow.ts`)
+ * inject the transport resolver, client ID, and system-browser opener. This
+ * module contains no DOM or React Native APIs.
+ *
+ * - `start()` requests a device code, opens GitHub's verification URL, and begins polling.
+ * - `cancel()` aborts the in-flight poll and resets state.
+ *
+ * Caller is responsible for persisting the resulting `token`.
+ */
+export function useDeviceFlow(options: UseDeviceFlowOptions) {
+  const [state, setState] = useState<DeviceFlowState>(INITIAL_STATE);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Keep the latest options reachable from the memoized start() without
+  // forcing consumers to memoize their callbacks.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Cancel any in-flight poll if the component unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState(INITIAL_STATE);
+  }, []);
+
+  const start = useCallback(async () => {
+    const { getAvailability, clientId, openVerificationUrl } = optionsRef.current;
+
+    const availability = getAvailability();
+    if (!availability.available || !availability.transport) {
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: availability.reason ?? 'OAuth is unavailable.',
+      });
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState({ status: 'requesting', device: null, token: null, error: null });
+
+    let device: DeviceCodeResponse;
+    try {
+      device = await requestDeviceCode(availability.transport, clientId);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: err instanceof Error ? err.message : 'Failed to request device code',
+      });
+      return;
+    }
+
+    // Bail if cancel() (or a newer start()) aborted while the request was in flight.
+    if (controller.signal.aborted) return;
+
+    setState({ status: 'awaiting', device, token: null, error: null });
+
+    try {
+      openVerificationUrl(device.verification_uri);
+    } catch {
+      // Platform opener failed; user can copy the URL manually.
+    }
+
+    try {
+      const token = await pollAccessToken(availability.transport, clientId, device.device_code, {
+        intervalSeconds: device.interval,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      setState({ status: 'success', device, token, error: null });
+    } catch (err) {
+      if (err instanceof DeviceFlowAbortedError) return;
+      setState({
+        status: 'error',
+        device,
+        token: null,
+        error: err instanceof Error ? err.message : 'OAuth failed',
+      });
+    }
+  }, []);
+
+  return { state, start, cancel };
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -45,6 +45,13 @@ export {
 export type { DeviceCodeResponse, PollOptions } from './auth/deviceFlow.js';
 export type { AuthMethod } from './auth/method.js';
 export { getAuthMethod, authMethodLabel } from './auth/method.js';
+export { useDeviceFlow } from './auth/useDeviceFlow.js';
+export type {
+  DeviceFlowAvailability,
+  DeviceFlowState,
+  DeviceFlowStatus,
+  UseDeviceFlowOptions,
+} from './auth/useDeviceFlow.js';
 
 // Hooks
 export { useGithubData } from './hooks/useGithubData.js';

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -31,6 +31,21 @@ export { filterByPRState } from './utils/prStateFilter.js';
 export { groupByMilestone } from './utils/milestoneGrouping.js';
 export type { MilestoneGroup } from './utils/milestoneGrouping.js';
 
+// Auth (OAuth Device Flow)
+export type { DeviceFlowTransport } from './auth/transport.js';
+export {
+  DEFAULT_OAUTH_SCOPE,
+  GITHUB_DEVICE_CODE_URL,
+  GITHUB_ACCESS_TOKEN_URL,
+  DeviceFlowError,
+  DeviceFlowAbortedError,
+  requestDeviceCode,
+  pollAccessToken,
+} from './auth/deviceFlow.js';
+export type { DeviceCodeResponse, PollOptions } from './auth/deviceFlow.js';
+export type { AuthMethod } from './auth/method.js';
+export { getAuthMethod, authMethodLabel } from './auth/method.js';
+
 // Hooks
 export { useGithubData } from './hooks/useGithubData.js';
 export { useFilteredItems } from './hooks/useFilteredItems.js';

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import type { DashboardItem, OwnershipFilter } from './types.js';
 import { createClient, type RateLimit } from './github/client.js';
 import { isAuthError } from './github/errors.js';
 import { getToken, setToken as saveToken, clearToken } from './config.js';
+import { getAuthMethod } from '../shared/auth/method.js';
 import { useConfig } from './hooks/useConfig.js';
 import { useGithubData } from './hooks/useGithubData.js';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts.js';
@@ -222,6 +223,7 @@ export function App() {
         onSignOut={handleSignOut}
         onRefresh={handleRefresh}
         autoRefreshSecondsLeft={autoRefreshSecondsLeft}
+        authMethod={getAuthMethod(token)}
       />
       <FilterBar
         active={filter}

--- a/src/auth/electronBridge.ts
+++ b/src/auth/electronBridge.ts
@@ -8,6 +8,9 @@ interface ElectronAPI {
   oauthDeviceFlow: {
     postForm(url: string, body: Record<string, string>): Promise<Record<string, unknown>>;
   };
+  clipboard?: {
+    writeText(text: string): void;
+  };
 }
 
 declare global {
@@ -23,4 +26,48 @@ export function getElectronOAuthTransport(): DeviceFlowTransport | null {
   return {
     postForm: (url, body) => api.oauthDeviceFlow.postForm(url, body),
   };
+}
+
+/**
+ * Copy text to the system clipboard. Prefers Electron's native clipboard
+ * (via the preload bridge) because `navigator.clipboard.writeText` is
+ * unreliable in Electron renderers. Falls back to the web Clipboard API,
+ * then to a hidden-textarea `document.execCommand('copy')` as a last resort.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof window === 'undefined') return false;
+
+  const electronClipboard = window.electronAPI?.clipboard;
+  if (electronClipboard?.writeText) {
+    try {
+      electronClipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through
+    }
+  }
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through
+    }
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
 }

--- a/src/auth/electronBridge.ts
+++ b/src/auth/electronBridge.ts
@@ -1,0 +1,26 @@
+/**
+ * Typed access to the preload-injected `window.electronAPI` bridge.
+ * Returns `null` when running in a plain browser context.
+ */
+import type { DeviceFlowTransport } from '../../shared/auth/transport.js';
+
+interface ElectronAPI {
+  oauthDeviceFlow: {
+    postForm(url: string, body: Record<string, string>): Promise<Record<string, unknown>>;
+  };
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI;
+  }
+}
+
+export function getElectronOAuthTransport(): DeviceFlowTransport | null {
+  if (typeof window === 'undefined') return null;
+  const api = window.electronAPI;
+  if (!api?.oauthDeviceFlow?.postForm) return null;
+  return {
+    postForm: (url, body) => api.oauthDeviceFlow.postForm(url, body),
+  };
+}

--- a/src/auth/oauthConfig.ts
+++ b/src/auth/oauthConfig.ts
@@ -1,0 +1,34 @@
+import type { DeviceFlowTransport } from '../../shared/auth/transport.js';
+import { getElectronOAuthTransport } from './electronBridge.js';
+
+/**
+ * GitHub OAuth App `client_id` for Device Flow login.
+ * Set `VITE_GITHUB_OAUTH_CLIENT_ID` at build time. When unset, OAuth is
+ * disabled and the UI falls back to PAT entry.
+ */
+export const OAUTH_CLIENT_ID: string =
+  (import.meta.env.VITE_GITHUB_OAUTH_CLIENT_ID as string | undefined) ?? '';
+
+export interface OAuthAvailability {
+  available: boolean;
+  /** When unavailable, a short reason for display to the user. */
+  reason?: string;
+  transport?: DeviceFlowTransport;
+}
+
+export function getOAuthAvailability(): OAuthAvailability {
+  if (!OAUTH_CLIENT_ID) {
+    return {
+      available: false,
+      reason: 'OAuth is not configured for this build (VITE_GITHUB_OAUTH_CLIENT_ID is unset).',
+    };
+  }
+  const transport = getElectronOAuthTransport();
+  if (!transport) {
+    return {
+      available: false,
+      reason: 'Browser OAuth login is unavailable here. Use a Personal Access Token.',
+    };
+  }
+  return { available: true, transport };
+}

--- a/src/auth/useDeviceFlow.ts
+++ b/src/auth/useDeviceFlow.ts
@@ -1,110 +1,22 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  requestDeviceCode,
-  pollAccessToken,
-  DeviceFlowAbortedError,
-  type DeviceCodeResponse,
-} from '../../shared/auth/deviceFlow.js';
+import { useDeviceFlow as useSharedDeviceFlow } from '../../shared/auth/useDeviceFlow.js';
 import { OAUTH_CLIENT_ID, getOAuthAvailability } from './oauthConfig.js';
 
-export type DeviceFlowStatus = 'idle' | 'requesting' | 'awaiting' | 'success' | 'error';
-
-export interface DeviceFlowState {
-  status: DeviceFlowStatus;
-  device: DeviceCodeResponse | null;
-  token: string | null;
-  error: string | null;
-}
-
-const INITIAL_STATE: DeviceFlowState = {
-  status: 'idle',
-  device: null,
-  token: null,
-  error: null,
-};
+export type { DeviceFlowState, DeviceFlowStatus } from '../../shared/auth/useDeviceFlow.js';
 
 /**
- * Drives the GitHub Device Flow from the renderer.
- * - `start()` requests a device code, opens GitHub's verification URL, and begins polling.
- * - `cancel()` aborts the in-flight poll and resets state.
- *
- * Caller is responsible for persisting the resulting `token`.
+ * Open a URL in the system browser. In Electron, `setWindowOpenHandler`
+ * routes http(s) URLs through `shell.openExternal`; in a plain browser this
+ * opens a new tab (when not blocked by the popup blocker).
  */
+function openInSystemBrowser(url: string): void {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+/** Web/Electron wrapper around the shared Device Flow state machine. */
 export function useDeviceFlow() {
-  const [state, setState] = useState<DeviceFlowState>(INITIAL_STATE);
-  const abortRef = useRef<AbortController | null>(null);
-
-  // Cancel any in-flight poll if the component unmounts.
-  useEffect(() => () => abortRef.current?.abort(), []);
-
-  const cancel = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setState(INITIAL_STATE);
-  }, []);
-
-  const start = useCallback(async () => {
-    const availability = getOAuthAvailability();
-    if (!availability.available || !availability.transport) {
-      setState({
-        status: 'error',
-        device: null,
-        token: null,
-        error: availability.reason ?? 'OAuth is unavailable.',
-      });
-      return;
-    }
-
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setState({ status: 'requesting', device: null, token: null, error: null });
-
-    let device: DeviceCodeResponse;
-    try {
-      device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      setState({
-        status: 'error',
-        device: null,
-        token: null,
-        error: err instanceof Error ? err.message : 'Failed to request device code',
-      });
-      return;
-    }
-
-    // Bail if cancel() (or a newer start()) aborted while the request was in flight.
-    if (controller.signal.aborted) return;
-
-    setState({ status: 'awaiting', device, token: null, error: null });
-
-    // Open the verification URL in the system browser. In Electron, the
-    // window-open handler routes http(s) URLs through `shell.openExternal`.
-    try {
-      window.open(device.verification_uri, '_blank', 'noopener,noreferrer');
-    } catch {
-      // Ignore — the user can copy the URL manually.
-    }
-
-    try {
-      const token = await pollAccessToken(availability.transport, OAUTH_CLIENT_ID, device.device_code, {
-        intervalSeconds: device.interval,
-        signal: controller.signal,
-      });
-      if (controller.signal.aborted) return;
-      setState({ status: 'success', device, token, error: null });
-    } catch (err) {
-      if (err instanceof DeviceFlowAbortedError) return;
-      setState({
-        status: 'error',
-        device,
-        token: null,
-        error: err instanceof Error ? err.message : 'OAuth failed',
-      });
-    }
-  }, []);
-
-  return { state, start, cancel };
+  return useSharedDeviceFlow({
+    getAvailability: getOAuthAvailability,
+    clientId: OAUTH_CLIENT_ID,
+    openVerificationUrl: openInSystemBrowser,
+  });
 }

--- a/src/auth/useDeviceFlow.ts
+++ b/src/auth/useDeviceFlow.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  requestDeviceCode,
+  pollAccessToken,
+  DeviceFlowAbortedError,
+  type DeviceCodeResponse,
+} from '../../shared/auth/deviceFlow.js';
+import { OAUTH_CLIENT_ID, getOAuthAvailability } from './oauthConfig.js';
+
+export type DeviceFlowStatus = 'idle' | 'requesting' | 'awaiting' | 'success' | 'error';
+
+export interface DeviceFlowState {
+  status: DeviceFlowStatus;
+  device: DeviceCodeResponse | null;
+  token: string | null;
+  error: string | null;
+}
+
+const INITIAL_STATE: DeviceFlowState = {
+  status: 'idle',
+  device: null,
+  token: null,
+  error: null,
+};
+
+/**
+ * Drives the GitHub Device Flow from the renderer.
+ * - `start()` requests a device code, opens GitHub's verification URL, and begins polling.
+ * - `cancel()` aborts the in-flight poll and resets state.
+ *
+ * Caller is responsible for persisting the resulting `token`.
+ */
+export function useDeviceFlow() {
+  const [state, setState] = useState<DeviceFlowState>(INITIAL_STATE);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Cancel any in-flight poll if the component unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState(INITIAL_STATE);
+  }, []);
+
+  const start = useCallback(async () => {
+    const availability = getOAuthAvailability();
+    if (!availability.available || !availability.transport) {
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: availability.reason ?? 'OAuth is unavailable.',
+      });
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState({ status: 'requesting', device: null, token: null, error: null });
+
+    let device: DeviceCodeResponse;
+    try {
+      device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
+    } catch (err) {
+      setState({
+        status: 'error',
+        device: null,
+        token: null,
+        error: err instanceof Error ? err.message : 'Failed to request device code',
+      });
+      return;
+    }
+
+    setState({ status: 'awaiting', device, token: null, error: null });
+
+    // Open the verification URL in the system browser. In Electron, the
+    // window-open handler routes http(s) URLs through `shell.openExternal`.
+    try {
+      window.open(device.verification_uri, '_blank', 'noopener,noreferrer');
+    } catch {
+      // Ignore — the user can copy the URL manually.
+    }
+
+    try {
+      const token = await pollAccessToken(availability.transport, OAUTH_CLIENT_ID, device.device_code, {
+        intervalSeconds: device.interval,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      setState({ status: 'success', device, token, error: null });
+    } catch (err) {
+      if (err instanceof DeviceFlowAbortedError) return;
+      setState({
+        status: 'error',
+        device,
+        token: null,
+        error: err instanceof Error ? err.message : 'OAuth failed',
+      });
+    }
+  }, []);
+
+  return { state, start, cancel };
+}

--- a/src/auth/useDeviceFlow.ts
+++ b/src/auth/useDeviceFlow.ts
@@ -65,6 +65,7 @@ export function useDeviceFlow() {
     try {
       device = await requestDeviceCode(availability.transport, OAUTH_CLIENT_ID);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setState({
         status: 'error',
         device: null,
@@ -73,6 +74,9 @@ export function useDeviceFlow() {
       });
       return;
     }
+
+    // Bail if cancel() (or a newer start()) aborted while the request was in flight.
+    if (controller.signal.aborted) return;
 
     setState({ status: 'awaiting', device, token: null, error: null });
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { version } from '../../package.json';
+import { authMethodLabel, type AuthMethod } from '../../shared/auth/method.js';
 
 interface HeaderProps {
   loading: boolean;
@@ -11,6 +12,7 @@ interface HeaderProps {
   onSignOut: () => void;
   onRefresh: () => void;
   autoRefreshSecondsLeft: number | null;
+  authMethod: AuthMethod | null;
 }
 
 function formatCountdown(seconds: number): string {
@@ -29,6 +31,7 @@ export function Header({
   onSignOut,
   onRefresh,
   autoRefreshSecondsLeft,
+  authMethod,
 }: HeaderProps) {
   return (
     <header className="header">
@@ -70,6 +73,14 @@ export function Header({
         <button className="header-btn" onClick={onOpenRepos} title="Manage repos (c)">
           Repos
         </button>
+        {authMethod && (
+          <span
+            className={`auth-method-badge auth-method-${authMethod}`}
+            title={`Connected via ${authMethodLabel(authMethod)}`}
+          >
+            {authMethod === 'oauth' ? 'OAuth' : 'PAT'}
+          </span>
+        )}
         <button className="header-btn header-btn-subtle" onClick={onSignOut} title="Sign out">
           Sign out
         </button>

--- a/src/components/TokenSetup.tsx
+++ b/src/components/TokenSetup.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { copyTextToClipboard } from '../auth/electronBridge.js';
 import { getOAuthAvailability } from '../auth/oauthConfig.js';
 import { useDeviceFlow } from '../auth/useDeviceFlow.js';
 
@@ -42,12 +43,10 @@ export function TokenSetup({ onSave, reason }: TokenSetupProps) {
 
   const copyCode = async () => {
     if (!state.device?.user_code) return;
-    try {
-      await navigator.clipboard.writeText(state.device.user_code);
+    const ok = await copyTextToClipboard(state.device.user_code);
+    if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard may be unavailable; ignore — the code is visible on screen.
     }
   };
 

--- a/src/components/TokenSetup.tsx
+++ b/src/components/TokenSetup.tsx
@@ -1,18 +1,53 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { getOAuthAvailability } from '../auth/oauthConfig.js';
+import { useDeviceFlow } from '../auth/useDeviceFlow.js';
 
 interface TokenSetupProps {
   onSave: (token: string) => void;
   reason?: 'expired' | null;
 }
 
+type Mode = 'oauth' | 'pat';
+
 export function TokenSetup({ onSave, reason }: TokenSetupProps) {
+  // OAuth availability is fixed for the lifetime of the page; compute once.
+  const oauthAvailability = useMemo(() => getOAuthAvailability(), []);
+  const [mode, setMode] = useState<Mode>(oauthAvailability.available ? 'oauth' : 'pat');
+
+  const { state, start, cancel } = useDeviceFlow();
   const [token, setToken] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // Persist the token as soon as polling succeeds.
+  useEffect(() => {
+    if (state.status === 'success' && state.token) {
+      onSave(state.token);
+    }
+  }, [state.status, state.token, onSave]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = token.trim();
-    if (trimmed) {
-      onSave(trimmed);
+    if (trimmed) onSave(trimmed);
+  };
+
+  const switchToPat = () => {
+    cancel();
+    setMode('pat');
+  };
+
+  const switchToOAuth = () => {
+    setMode('oauth');
+  };
+
+  const copyCode = async () => {
+    if (!state.device?.user_code) return;
+    try {
+      await navigator.clipboard.writeText(state.device.user_code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be unavailable; ignore — the code is visible on screen.
     }
   };
 
@@ -20,42 +55,158 @@ export function TokenSetup({ onSave, reason }: TokenSetupProps) {
     <div className="token-setup">
       <div className="token-card">
         <h1>Git Dashboard</h1>
-        {reason === 'expired' ? (
-          <p className="token-warning">Your GitHub token is invalid or expired. Please enter a new one.</p>
-        ) : (
-          <p>Enter a GitHub Personal Access Token to get started.</p>
+        {reason === 'expired' && (
+          <p className="token-warning">Your GitHub credentials are invalid or expired. Please reconnect.</p>
         )}
-        <p className="token-hint">
-          To create a token:
-        </p>
-        <ol className="token-steps">
-          <li>Go to{' '}
-            <a
-              href="https://github.com/settings/tokens"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              github.com/settings/tokens
-            </a>
-          </li>
-          <li>Click <strong>Generate new token (classic)</strong></li>
-          <li>Select the <code>repo</code> scope</li>
-          <li>Copy and paste the token below</li>
-        </ol>
-        <form onSubmit={handleSubmit}>
-          <input
-            type="password"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="ghp_..."
-            className="token-input"
-            autoFocus
+
+        {mode === 'oauth' && oauthAvailability.available ? (
+          <OAuthPanel
+            state={state}
+            onStart={start}
+            onCancel={cancel}
+            onCopyCode={copyCode}
+            copied={copied}
+            onUsePat={switchToPat}
           />
-          <button type="submit" className="token-btn" disabled={!token.trim()}>
-            Save & Continue
-          </button>
-        </form>
+        ) : (
+          <PatPanel
+            token={token}
+            onTokenChange={setToken}
+            onSubmit={handleSubmit}
+            oauthReason={oauthAvailability.available ? null : oauthAvailability.reason ?? null}
+            onUseOAuth={oauthAvailability.available ? switchToOAuth : undefined}
+          />
+        )}
       </div>
     </div>
+  );
+}
+
+function OAuthPanel({
+  state,
+  onStart,
+  onCancel,
+  onCopyCode,
+  copied,
+  onUsePat,
+}: {
+  state: ReturnType<typeof useDeviceFlow>['state'];
+  onStart: () => void;
+  onCancel: () => void;
+  onCopyCode: () => void;
+  copied: boolean;
+  onUsePat: () => void;
+}) {
+  if (state.status === 'awaiting' && state.device) {
+    return (
+      <>
+        <p>Authorize Git Dashboard on GitHub to finish signing in.</p>
+        <ol className="token-steps">
+          <li>
+            Open{' '}
+            <a href={state.device.verification_uri} target="_blank" rel="noopener noreferrer">
+              {state.device.verification_uri}
+            </a>{' '}
+            (a new tab should already be open).
+          </li>
+          <li>Enter the code below.</li>
+          <li>Approve access — the dashboard will continue automatically.</li>
+        </ol>
+        <div className="token-user-code" aria-label="One-time device code">
+          <code>{state.device.user_code}</code>
+          <button type="button" className="token-link-btn" onClick={onCopyCode}>
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <p className="token-hint">Waiting for you to approve in GitHub…</p>
+        <button type="button" className="token-btn token-btn-secondary" onClick={onCancel}>
+          Cancel
+        </button>
+        <p className="token-fallback">
+          Trouble signing in?{' '}
+          <button type="button" className="token-link-btn" onClick={onUsePat}>
+            Use a Personal Access Token instead
+          </button>
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p>Sign in with your GitHub account to read pull requests across your repos.</p>
+      {state.status === 'error' && state.error && <p className="token-error">{state.error}</p>}
+      <button
+        type="button"
+        className="token-btn"
+        onClick={onStart}
+        disabled={state.status === 'requesting'}
+      >
+        {state.status === 'requesting' ? 'Connecting…' : 'Connect with GitHub'}
+      </button>
+      <p className="token-fallback">
+        Prefer a manual token?{' '}
+        <button type="button" className="token-link-btn" onClick={onUsePat}>
+          Use a Personal Access Token instead
+        </button>
+      </p>
+    </>
+  );
+}
+
+function PatPanel({
+  token,
+  onTokenChange,
+  onSubmit,
+  oauthReason,
+  onUseOAuth,
+}: {
+  token: string;
+  onTokenChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  oauthReason: string | null;
+  onUseOAuth?: () => void;
+}) {
+  return (
+    <>
+      <p>Enter a GitHub Personal Access Token to get started.</p>
+      {oauthReason && <p className="token-hint token-fallback-note">{oauthReason}</p>}
+      <p className="token-hint">To create a token:</p>
+      <ol className="token-steps">
+        <li>
+          Go to{' '}
+          <a
+            href="https://github.com/settings/tokens"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/settings/tokens
+          </a>
+        </li>
+        <li>Click <strong>Generate new token (classic)</strong></li>
+        <li>Select the <code>repo</code> scope</li>
+        <li>Copy and paste the token below</li>
+      </ol>
+      <form onSubmit={onSubmit}>
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => onTokenChange(e.target.value)}
+          placeholder="ghp_..."
+          className="token-input"
+          autoFocus
+        />
+        <button type="submit" className="token-btn" disabled={!token.trim()}>
+          Save & Continue
+        </button>
+      </form>
+      {onUseOAuth && (
+        <p className="token-fallback">
+          <button type="button" className="token-link-btn" onClick={onUseOAuth}>
+            Connect with GitHub OAuth instead
+          </button>
+        </p>
+      )}
+    </>
   );
 }

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -125,6 +125,25 @@
   }
 }
 
+/* ── Auth Method Badge ─────────────────────────────────────── */
+.auth-method-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-surface);
+}
+
+.auth-method-badge.auth-method-oauth {
+  border-color: rgba(35, 134, 54, 0.5);
+  color: #3fb950;
+}
+
 /* ── Unseen / New Activity ─────────────────────────────────── */
 .unseen-badge {
   display: inline-flex;

--- a/src/styles/TokenSetup.css
+++ b/src/styles/TokenSetup.css
@@ -90,3 +90,71 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.token-btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  margin-top: 8px;
+}
+
+.token-btn-secondary:hover {
+  background: var(--bg);
+  opacity: 1;
+}
+
+.token-fallback {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.token-fallback-note {
+  margin-bottom: 12px;
+  font-style: italic;
+}
+
+.token-link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+.token-link-btn:hover {
+  opacity: 0.8;
+}
+
+.token-user-code {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.token-user-code code {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.token-error {
+  color: var(--danger, #f85149);
+  background: rgba(248, 81, 73, 0.08);
+  border: 1px solid rgba(248, 81, 73, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GITHUB_OAUTH_CLIENT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Closes #118

## Summary
- Adds GitHub **OAuth Device Flow** as the default sign-in path on the desktop and iOS builds. Device Flow needs no `client_secret` and no backend, so it's the only OAuth grant that fits this client-only app.
- Keeps **Personal Access Token** entry as a first-class fallback — explicitly chosen by the user, or automatically when OAuth is unavailable (pure browser builds, or builds without an OAuth client ID).
- The active connection method is shown in the desktop header (badge next to *Sign out*) and the iOS Settings → Account row.

## How it works
| Build target | OAuth available | Why |
|---|---|---|
| Electron desktop | Yes | Main process proxies the OAuth POSTs through `net.fetch`, bypassing the renderer's CORS. The bridge uses a strict allow-list of two GitHub URLs. |
| iOS / mobile | Yes | React Native's native `fetch` has no CORS. |
| Browser (`npm run dev`, preview) | No | GitHub's `/login/device/code` and `/login/oauth/access_token` don't return CORS headers; renders the PAT form with an explanatory note. |

Auth method is derived from the token prefix (`gho_` → OAuth, `ghp_`/`github_pat_` → PAT) — no extra storage state to keep in sync.

## Configuration
Project owner adds a **Client ID** (no secret) at build time:
- Web / Electron: `VITE_GITHUB_OAUTH_CLIENT_ID`
- Mobile (Expo): `EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID`

When unset, the apps gracefully degrade to PAT entry. Setup steps are documented in the updated README.

## What's in the diff
- `shared/auth/` — protocol logic for Device Flow (`requestDeviceCode`, `pollAccessToken` with `slow_down` / `expired_token` / `access_denied` handling), token-prefix classifier, and unit tests.
- `electron/preload.cjs` + main-process IPC handler with allow-listed URLs.
- `src/auth/` + `src/components/TokenSetup.tsx` rewrite — two-pane UI (OAuth panel with user code, PAT panel) with link buttons to switch.
- `mobile/src/auth/` + `mobile/src/screens/TokenSetupScreen.tsx` — RN equivalents using `Linking.openURL` and native fetch.
- Header / Settings indicators + new badge styles.
- README setup docs.

## Test plan
- [x] `npm test` — 246/246 passing (includes 17 new tests for the device flow + classifier).
- [x] `npm run build` — clean type check + production build.
- [x] `npx tsc --noEmit` (mobile) — no new errors; the 3 pre-existing Octokit-version mismatch errors are unchanged.
- [ ] Manual: configure `VITE_GITHUB_OAUTH_CLIENT_ID`, run `npm run electron:dev`, click **Connect with GitHub**, approve on github.com, verify dashboard loads with the **OAuth** badge in the header.
- [ ] Manual: build with no client ID set; verify the sign-in screen shows the PAT form with the "OAuth is not configured" note.
- [ ] Manual: iOS simulator with `EXPO_PUBLIC_GITHUB_OAUTH_CLIENT_ID` set; verify the device-code screen and the **Settings → Connection** row.
- [ ] Existing Playwright e2e suite (PAT flow) still passes — no selectors changed.

## Notes / follow-ups
- A GitHub OAuth App must be registered before users can use OAuth in any deployed build. Steps are in the README.
- Web (browser) OAuth would require a small backend/proxy; intentionally out of scope here. The fallback message points users at the PAT path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth Device Flow (default when configured) with PAT fallback; Token Setup UI supports mode switching, shows device code/verification link with copy-to-clipboard, auto-saves OAuth tokens, surfaces save/retry errors, and displays an auth-method badge in the header.

* **Documentation**
  * README adds "Connecting to GitHub", OAuth vs PAT guidance, build-target availability matrix, and platform-specific env var instructions.

* **Tests**
  * Added device-flow and auth-method test suites.

* **Style**
  * New styles for Token Setup UI and auth-method badge.

* **Chores**
  * .gitignore updated to ignore env files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->