### PR TITLE
Rename product to LandinGit (display-name pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,6 @@
 - Column visibility and reorder customization.
 - Auto-refresh with configurable interval.
 - Desktop app support via Electron (macOS, Linux, Windows).
-- CLI support via `npx git-dashboard`.
+- CLI support via `npx landingit` (previously `npx git-dashboard`).
 - Rate limit monitoring in the header.
 - Unseen PR indicators.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code Instructions — LandinGit
 
-> Repository slug is still `git-dashboard` in some local clones; the canonical slug is now `landingit`. iOS bundle identifier and Electron `appId` are intentionally still `com.github.adamsilverstein.git-dashboard` — see #120 for the migration plan before changing those.
+> Repository slug is still `git-dashboard` in some local clones; the canonical slug is now `landingit`. iOS bundle identifier and Electron `appId` have been updated to `com.github.adamsilverstein.landingit` (see #120).
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
-# Claude Code Instructions — Git Dashboard
+# Claude Code Instructions — LandinGit
+
+> Repository slug is still `git-dashboard` in some local clones; the canonical slug is now `landingit`. iOS bundle identifier and Electron `appId` are intentionally still `com.github.adamsilverstein.git-dashboard` — see #120 for the migration plan before changing those.
 
 ## Project Overview
 
-Git Dashboard is a GitHub PR monitoring tool with three targets:
+LandinGit (formerly "Git Dashboard") is a GitHub PR monitoring tool with three targets:
 - **Web app** (`src/`) — React + TypeScript + Vite
 - **Desktop app** (`electron/`) — Electron wrapper around the web app
 - **iOS app** (`mobile/`) — React Native (Expo) for iPhone/iPad
@@ -12,7 +14,7 @@ All three share platform-agnostic business logic from the `shared/` directory.
 ## Architecture
 
 ```
-git-dashboard/
+landingit/
   shared/       ← Types, GitHub API, hooks, utils (used by web + mobile)
   src/          ← Web app (re-exports from shared/, adds web-specific UI)
   mobile/       ← Expo React Native iOS app (imports from shared/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Git Dashboard
+# LandinGit
 
-A lightweight, keyboard-driven GitHub PR dashboard built with React and TypeScript. Browse pull requests across multiple repositories with real-time CI status, review state tracking, and vim-style keyboard navigation — all from your browser.
+> _"Land it."_ — the keyboard-first dashboard where every pull request, issue, and review across your repos actually lands, instead of drowning your inbox.
+
+A lightweight, keyboard-driven GitHub PR dashboard built with React and TypeScript. Browse pull requests across multiple repositories with real-time CI status, review state tracking, and vim-style keyboard navigation — all from your browser, your desktop, or your phone.
 
 ## Features
 
@@ -27,8 +29,8 @@ A lightweight, keyboard-driven GitHub PR dashboard built with React and TypeScri
 ### Installation
 
 ```bash
-git clone https://github.com/adamsilverstein/git-dashboard.git
-cd git-dashboard
+git clone https://github.com/adamsilverstein/landingit.git
+cd landingit
 npm install
 npm run dev
 ```
@@ -73,7 +75,7 @@ If the client ID is unset (or you're running in a plain browser), the sign-in sc
 
 1. Go to [github.com/settings/tokens](https://github.com/settings/tokens)
 2. Click **Generate new token** (classic)
-3. Give the token a descriptive name (e.g. "Git Dashboard")
+3. Give the token a descriptive name (e.g. "LandinGit")
 4. Select the **`repo`** scope — this grants read access to pull requests, commits, and check statuses for both public and private repositories
 5. Click **Generate token** and copy the value
 6. Paste the token into the dashboard's setup screen and click **Save & Continue**

--- a/bin/landingit.mjs
+++ b/bin/landingit.mjs
@@ -44,10 +44,10 @@ function parseArgs() {
       noBrowser = true;
     } else if (args[i] === '--help' || args[i] === '-h') {
       console.log(`
-  git-dashboard — GitHub PR dashboard
+  landingit — GitHub PR dashboard
 
   Usage:
-    npx git-dashboard [options]
+    npx landingit [options]
 
   Options:
     -p, --port <number>  Port to listen on (default: 4173)
@@ -100,7 +100,7 @@ const server = createServer(async (req, res) => {
 
 server.listen(port, () => {
   const url = `http://localhost:${port}`;
-  console.log(`\n  🚀 Git Dashboard is running at ${url}\n`);
+  console.log(`\n  🚀 LandinGit is running at ${url}\n`);
   console.log(`  Press Ctrl+C to stop.\n`);
   if (!noBrowser) openBrowser(url);
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -25,7 +25,7 @@ test.describe('Token Setup', () => {
     await page.click('.token-btn');
     // Should now show the main app layout (header with title)
     await expect(page.locator('.header-title')).toBeVisible();
-    await expect(page.locator('.header-title')).toHaveText('Git Dashboard');
+    await expect(page.locator('.header-title')).toHaveText('LandinGit');
   });
 });
 
@@ -45,7 +45,7 @@ test.describe('Dashboard (with token)', () => {
   });
 
   test('shows header with repo count', async ({ page }) => {
-    await expect(page.locator('.header-title')).toHaveText('Git Dashboard');
+    await expect(page.locator('.header-title')).toHaveText('LandinGit');
     await expect(page.locator('.header-stats')).toContainText('1 repo');
   });
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-    <title>Git Dashboard</title>
+    <title>LandinGit</title>
   </head>
   <body>
     <div id="root"></div>

--- a/mobile/APP_STORE.md
+++ b/mobile/APP_STORE.md
@@ -25,7 +25,7 @@ Update `mobile/app.json` with your App Store details:
     "slug": "landingit",
     "version": "1.0.0",
     "ios": {
-      "bundleIdentifier": "com.github.adamsilverstein.git-dashboard",
+      "bundleIdentifier": "com.github.adamsilverstein.landingit",
       "buildNumber": "1",
       "supportsTablet": true
     }

--- a/mobile/APP_STORE.md
+++ b/mobile/APP_STORE.md
@@ -1,6 +1,6 @@
 # App Store Submission & Update Guide
 
-This guide covers the full process for submitting the Git Dashboard iOS app to the App Store and releasing updates.
+This guide covers the full process for submitting the LandinGit iOS app to the App Store and releasing updates.
 
 ## Prerequisites
 
@@ -21,8 +21,8 @@ Update `mobile/app.json` with your App Store details:
 ```json
 {
   "expo": {
-    "name": "Git Dashboard",
-    "slug": "git-dashboard",
+    "name": "LandinGit",
+    "slug": "landingit",
     "version": "1.0.0",
     "ios": {
       "bundleIdentifier": "com.github.adamsilverstein.git-dashboard",
@@ -50,10 +50,10 @@ This creates `eas.json` with build profiles. The recommended configuration is al
 2. Click **My Apps** > **+** > **New App**
 3. Fill in:
    - **Platform**: iOS
-   - **Name**: Git Dashboard
+   - **Name**: LandinGit
    - **Primary Language**: English (U.S.)
    - **Bundle ID**: Select the one matching your `bundleIdentifier`
-   - **SKU**: `git-dashboard-ios`
+   - **SKU**: `landingit-ios`
 4. Save
 
 ### 4. Generate Apple Credentials
@@ -117,7 +117,7 @@ In [App Store Connect](https://appstoreconnect.apple.com):
      - iPad Pro 12.9": 2048 x 2732 (if supporting iPad)
    - Description:
      ```
-     Monitor your GitHub pull requests on the go. Git Dashboard brings
+     Monitor your GitHub pull requests on the go. LandinGit brings
      your PR workflow to iOS with real-time CI status, review tracking,
      and powerful filtering — all from one screen.
 
@@ -132,7 +132,7 @@ In [App Store Connect](https://appstoreconnect.apple.com):
      • Dark theme matching GitHub's design
      ```
    - Keywords: `github, pull requests, code review, ci, developer tools, git`
-   - Support URL: `https://github.com/adamsilverstein/git-dashboard/issues`
+   - Support URL: `https://github.com/adamsilverstein/landingit/issues`
 
 5. **Review Information**
    - Notes for reviewer:

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -14,7 +14,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.github.adamsilverstein.git-dashboard",
+      "bundleIdentifier": "com.github.adamsilverstein.landingit",
       "buildNumber": "1"
     },
     "android": {

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "Git Dashboard",
-    "slug": "git-dashboard",
+    "name": "LandinGit",
+    "slug": "landingit",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -169,7 +169,7 @@ export function SettingsScreen() {
       </View>
 
       <View style={styles.footer}>
-        <Text style={styles.footerText}>Git Dashboard iOS v1.0.0</Text>
+        <Text style={styles.footerText}>LandinGit iOS v1.0.0</Text>
       </View>
     </ScrollView>
   );

--- a/mobile/src/screens/TokenSetupScreen.tsx
+++ b/mobile/src/screens/TokenSetupScreen.tsx
@@ -81,7 +81,7 @@ export function TokenSetupScreen() {
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
       <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-        <Text style={styles.title}>Git Dashboard</Text>
+        <Text style={styles.title}>LandinGit</Text>
         <Text style={styles.subtitle}>GitHub PR Dashboard for iOS</Text>
 
         {mode === 'oauth' && oauthAvailability.available ? (

--- a/mobile/src/screens/TokenSetupScreen.tsx
+++ b/mobile/src/screens/TokenSetupScreen.tsx
@@ -263,7 +263,7 @@ function PatCard({
 
       <TouchableOpacity
         style={styles.linkButton}
-        onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo&description=Git+Dashboard+iOS')}
+        onPress={() => Linking.openURL('https://github.com/settings/tokens/new?scopes=repo&description=LandinGit+iOS')}
       >
         <Text style={styles.linkText}>Create a new token on GitHub</Text>
       </TouchableOpacity>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "git-dashboard",
+  "name": "landingit",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "git-dashboard",
+      "name": "landingit",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "remark-gfm": "^4.0.1"
       },
       "bin": {
-        "git-dashboard": "bin/git-dashboard.mjs"
+        "landingit": "bin/landingit.mjs"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "build": {
-    "appId": "com.github.adamsilverstein.git-dashboard",
+    "appId": "com.github.adamsilverstein.landingit",
     "productName": "LandinGit",
     "directories": {
       "output": "release"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "git-dashboard",
+  "name": "landingit",
   "version": "1.0.0",
-  "description": "GitHub PR dashboard web app",
+  "description": "LandinGit — the keyboard-first GitHub PR dashboard",
   "type": "module",
   "main": "electron/main.cjs",
   "bin": {
-    "git-dashboard": "./bin/git-dashboard.mjs"
+    "landingit": "./bin/landingit.mjs"
   },
   "files": [
     "bin",
@@ -24,7 +24,7 @@
   },
   "build": {
     "appId": "com.github.adamsilverstein.git-dashboard",
-    "productName": "Git Dashboard",
+    "productName": "LandinGit",
     "directories": {
       "output": "release"
     },
@@ -63,7 +63,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/adamsilverstein/git-dashboard.git"
+    "url": "https://github.com/adamsilverstein/landingit.git"
   },
   "dependencies": {
     "@octokit/rest": "^21.0.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header({
     <header className="header">
       <div className="header-left">
         <div className="header-title-block">
-          <h1 className="header-title">Git Dashboard</h1>
+          <h1 className="header-title">LandinGit</h1>
           <span className="header-version">v{version}</span>
         </div>
         <span className="header-stats">

--- a/src/components/TokenSetup.tsx
+++ b/src/components/TokenSetup.tsx
@@ -53,7 +53,7 @@ export function TokenSetup({ onSave, reason }: TokenSetupProps) {
   return (
     <div className="token-setup">
       <div className="token-card">
-        <h1>Git Dashboard</h1>
+        <h1>LandinGit</h1>
         {reason === 'expired' && (
           <p className="token-warning">Your GitHub credentials are invalid or expired. Please reconnect.</p>
         )}

--- a/src/components/TokenSetup.tsx
+++ b/src/components/TokenSetup.tsx
@@ -99,7 +99,7 @@ function OAuthPanel({
   if (state.status === 'awaiting' && state.device) {
     return (
       <>
-        <p>Authorize Git Dashboard on GitHub to finish signing in.</p>
+        <p>Authorize LandinGit on GitHub to finish signing in.</p>
         <ol className="token-steps">
           <li>
             Open{' '}


### PR DESCRIPTION
## Summary

First pass on the rename from **Git Dashboard** → **LandinGit** (#120). This PR is intentionally narrow: it changes user-facing display strings, the npm package name, and the CLI command — nothing that touches App Store identity, code signing, or stored user data.

## What changed

- `package.json` — `name`: `git-dashboard` → `landingit`; `bin`: `git-dashboard` → `landingit`; description, electron `productName`, repository URL
- `bin/git-dashboard.mjs` → `bin/landingit.mjs` (banner + help text updated)
- `index.html` page title
- Web headers: `src/components/Header.tsx`, `src/components/TokenSetup.tsx`
- Mobile screens: `TokenSetupScreen.tsx`, `SettingsScreen.tsx`
- `mobile/app.json` — `name` and `slug` (bundle identifier left as-is)
- README, CHANGELOG, CLAUDE.md, `mobile/APP_STORE.md`
- `e2e/dashboard.spec.ts` assertions

## Intentionally NOT changed

These need their own migration plans before flipping:

| Surface | Why deferred |
| --- | --- |
| iOS `bundleIdentifier` (`com.github.adamsilverstein.git-dashboard`) | Changing it = a brand-new App Store listing, not an update to the existing one |
| Electron `appId` | Changes the OS-level app identity, breaks code signing + auto-update |
| Native Xcode project dir (`mobile/ios/GitDashboard/…`) | Generated by `expo prebuild` from `app.json`; safer to regenerate than to hand-edit the pbxproj |
| Storage keys (`gh-dashboard-token`, `gh-dashboard-config`) | Changing without a one-time migration logs every existing user out and erases their saved filter sets |
| GitHub OAuth App registration | External, must be updated in GitHub UI |

## Test plan

- [x] `npm run build` — clean (TypeScript + Vite)
- [x] `npm test` — 229 unit tests pass
- [ ] Manual smoke: web app shows "LandinGit" in header + token-setup
- [ ] Manual smoke: Electron build still launches and shows the new product name
- [ ] iOS sim run still launches (display name will not change until next `expo prebuild` because the native artifacts are checked in)
- [ ] `npx landingit` works against a built `dist/`

## Related

- #120 — overall rename plan (open follow-ups for the deferred surfaces above will live there)
- #121 — README / landing-page work
- #122 — landing page implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project renamed from "Git Dashboard" to "LandinGit" across web, mobile, desktop, and CLI
  * CLI command switched to `npx landingit`; CLI/help and startup banner updated
  * Package name, product metadata, app identifiers, and repository references updated

* **Documentation**
  * README, CHANGELOG, app store and onboarding guides updated with new branding and setup instructions

* **Tests**
  * End-to-end assertions updated to expect the new UI title text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->