### PR TITLE
Fix: Escape key closes Manage Repositories dialog

### DIFF
--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -174,6 +174,14 @@ describe('useKeyboardShortcuts', () => {
       expect(actions.setViewMode).toHaveBeenCalledWith('list');
     });
 
+    it('Escape closes repos modal even when an input is focused', () => {
+      actions.viewMode = 'repos';
+      renderHook(() => useKeyboardShortcuts(actions));
+      const input = document.createElement('input');
+      pressKey('Escape', input);
+      expect(actions.setViewMode).toHaveBeenCalledWith('list');
+    });
+
     it('other keys are ignored in repos mode', () => {
       actions.viewMode = 'repos';
       renderHook(() => useKeyboardShortcuts(actions));

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -20,10 +20,11 @@ interface ShortcutActions {
 export function useKeyboardShortcuts(actions: ShortcutActions) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      // Skip when typing in inputs
+      // Skip when typing in inputs, except for Escape so modals can still close.
       if (
-        e.target instanceof HTMLInputElement ||
-        e.target instanceof HTMLTextAreaElement
+        e.key !== 'Escape' &&
+        (e.target instanceof HTMLInputElement ||
+          e.target instanceof HTMLTextAreaElement)
       ) {
         return;
       }


### PR DESCRIPTION
## Summary
- The global `useKeyboardShortcuts` handler skipped every key when focus was on an input or textarea, so the autofocused `owner/repo` input in the `RepoManager` modal swallowed `Escape` until the user clicked the modal to move focus.
- Allow `Escape` to bypass the input-skip check. `Escape` does not mutate input contents, and the per-mode modal handlers (`help`, `repos`, `detail`) already do the right thing once they receive the event.
- Added a test asserting `Escape` closes the repos modal even when an input is the event target.

Fixes #127

## Test plan
- [x] `npm test` — 248 tests pass (29 in `useKeyboardShortcuts.test.ts`, including the new "Escape closes repos modal even when an input is focused" case)
- [x] `npm run build` — TypeScript + Vite build clean
- [ ] Manual: open the dashboard, press `c` to open Manage Repositories, press `Esc` immediately — modal closes without an extra click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Escape key now properly closes modals and changes view modes when pressed inside input fields, while other keyboard shortcuts remain appropriately disabled during text entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->