### PR TITLE
Show Sign in with GitHub on desktop by defaulting the OAuth client_id

### DIFF
--- a/src/auth/oauthConfig.ts
+++ b/src/auth/oauthConfig.ts
@@ -2,12 +2,16 @@ import type { DeviceFlowTransport } from '../../shared/auth/transport.js';
 import { getElectronOAuthTransport } from './electronBridge.js';
 
 /**
- * GitHub OAuth App `client_id` for Device Flow login.
- * Set `VITE_GITHUB_OAUTH_CLIENT_ID` at build time. When unset, OAuth is
- * disabled and the UI falls back to PAT entry.
+ * GitHub OAuth App `client_id` for Device Flow login. Public, non-secret —
+ * Device Flow does not use a `client_secret`, and the value is visible in the
+ * verification URL users open. Checked in so CI-built desktop binaries (whose
+ * runners don't load local `.env`) ship with OAuth enabled. Forks can override
+ * via the `VITE_GITHUB_OAUTH_CLIENT_ID` env var at build time.
  */
+const DEFAULT_OAUTH_CLIENT_ID = 'Ov23liKbvHRiXEkU7xi3';
+
 export const OAUTH_CLIENT_ID: string =
-  (import.meta.env.VITE_GITHUB_OAUTH_CLIENT_ID as string | undefined) ?? '';
+  (import.meta.env.VITE_GITHUB_OAUTH_CLIENT_ID as string | undefined) ?? DEFAULT_OAUTH_CLIENT_ID;
 
 export interface OAuthAvailability {
   available: boolean;


### PR DESCRIPTION
Closes #131

## Summary

- Hardcode the public LandinGit OAuth `client_id` (`Ov23liKbvHRiXEkU7xi3`) as the fallback in `src/auth/oauthConfig.ts`
- Mirror of #130 (mobile) — same root cause, same minimal fix
- `VITE_GITHUB_OAUTH_CLIENT_ID` env var still overrides at build time, so forks can plug in their own OAuth App without code changes

## Why

`.github/workflows/build-desktop.yml` runs `npm run build` without passing `VITE_GITHUB_OAUTH_CLIENT_ID`, and the local `.env` holding the value is gitignored. The result: every DMG/AppImage/.deb/.exe published to GitHub Releases (v1.0.0–v1.0.2) shipped with `OAUTH_CLIENT_ID = ''`, making `getOAuthAvailability()` return unavailable and hiding the Sign-in-with-GitHub button on first run. Local dev builds were unaffected because Vite reads `.env` from disk — that's why this slipped through. See #131 for the full diagnosis.

GitHub OAuth `client_id` values are public, non-secret identifiers (they appear in plaintext in the verification URLs users open during Device Flow); only `client_secret` is sensitive, and Device Flow does not use one.

## Test plan

- [x] `npm run build` passes (TypeScript + Vite)
- [x] `npm test -- --run` — 248 passed
- [ ] After merge, cut a new tag (e.g. `v1.0.3`) → confirm the published DMG/AppImage/.exe show "Sign in with GitHub" on first launch
- [ ] Tap Connect with GitHub, complete approval in system browser, return to app — token saved, app advances to PR list