### PR TITLE
Phase 1: notifications foundations (types, API client, hooks, utils)

### DIFF
--- a/shared/config.ts
+++ b/shared/config.ts
@@ -10,6 +10,9 @@ const DEFAULT_CONFIG: Config = {
     maxPrsPerRepo: 30,
     autoRefreshInterval: 300, // 5 minutes in seconds, 0 = disabled
     staleDays: 14, // days of inactivity before an item is considered stale
+    notificationsEnabled: true,
+    notificationsRefreshInterval: 60, // 1 minute; 304 responses are free
+    highlightWorkingSet: true,
   },
 };
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -9,4 +9,6 @@ export const STORAGE_KEYS = {
   COLUMN_SETTINGS: 'gh-dashboard-column-settings',
   LABEL_FILTERS: 'gh-dashboard-label-filters',
   HIDE_MY_REPLIES: 'gh-dashboard-hide-my-replies',
+  NOTIFICATION_RULES: 'gh-dashboard-notification-rules',
+  NOTIFICATIONS_LAST_MODIFIED: 'gh-dashboard-notifications-last-modified',
 } as const;

--- a/shared/github/notifications.test.ts
+++ b/shared/github/notifications.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+import {
+  fetchNotifications,
+  markThreadAsRead,
+  markThreadsAsRead,
+  markAllAsRead,
+  mapNotification,
+} from './notifications.js';
+
+function mockOctokit(overrides: Record<string, unknown> = {}): Octokit {
+  return overrides as unknown as Octokit;
+}
+
+function rawNotification(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '12345',
+    unread: true,
+    reason: 'mention',
+    updated_at: '2026-05-12T10:00:00Z',
+    last_read_at: null,
+    subject: {
+      title: 'Bump @octokit/rest from 21.0.0 to 21.1.1',
+      type: 'PullRequest',
+      url: 'https://api.github.com/repos/acme/web/pulls/42',
+      latest_comment_url: 'https://api.github.com/repos/acme/web/issues/comments/9',
+    },
+    repository: {
+      name: 'web',
+      owner: { login: 'acme' },
+    },
+    ...over,
+  };
+}
+
+describe('mapNotification', () => {
+  it('maps a well-formed PR notification including parsed subjectNumber', () => {
+    const item = mapNotification(rawNotification());
+    expect(item).toMatchObject({
+      id: '12345',
+      unread: true,
+      reason: 'mention',
+      repo: { owner: 'acme', name: 'web' },
+      subject: {
+        title: 'Bump @octokit/rest from 21.0.0 to 21.1.1',
+        type: 'PullRequest',
+      },
+      subjectNumber: 42,
+    });
+  });
+
+  it('returns subjectNumber=null for non-PR/issue subjects', () => {
+    const raw = rawNotification({
+      subject: {
+        title: 'Release 1.0.0',
+        type: 'Release',
+        url: 'https://api.github.com/repos/acme/web/releases/1',
+        latest_comment_url: null,
+      },
+    });
+    const item = mapNotification(raw);
+    expect(item?.subjectNumber).toBeNull();
+  });
+
+  it('coerces a numeric id to string', () => {
+    const item = mapNotification(rawNotification({ id: 999 }));
+    expect(item?.id).toBe('999');
+  });
+
+  it('returns null when repository owner/name is missing', () => {
+    expect(mapNotification(rawNotification({ repository: undefined }))).toBeNull();
+    expect(
+      mapNotification(rawNotification({ repository: { name: 'web' } }))
+    ).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(mapNotification(null)).toBeNull();
+    expect(mapNotification('string')).toBeNull();
+    expect(mapNotification(undefined)).toBeNull();
+  });
+
+  it('defaults reason to "subscribed" when missing', () => {
+    const raw = rawNotification();
+    delete (raw as Record<string, unknown>).reason;
+    expect(mapNotification(raw)?.reason).toBe('subscribed');
+  });
+});
+
+describe('fetchNotifications', () => {
+  it('maps the response to NotificationItem objects', async () => {
+    const octokit = mockOctokit({
+      activity: {
+        listNotificationsForAuthenticatedUser: vi.fn().mockResolvedValue({
+          data: [rawNotification(), rawNotification({ id: '2' })],
+          headers: { 'last-modified': 'Tue, 12 May 2026 10:00:00 GMT' },
+        }),
+      },
+    });
+
+    const result = await fetchNotifications(octokit);
+    expect(result.notifications).toHaveLength(2);
+    expect(result.notifications[0].id).toBe('12345');
+    expect(result.lastModified).toBe('Tue, 12 May 2026 10:00:00 GMT');
+    expect(result.notModified).toBe(false);
+  });
+
+  it('sends If-Modified-Since when ifModifiedSince is provided', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: [], headers: {} });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await fetchNotifications(octokit, {
+      ifModifiedSince: 'Mon, 11 May 2026 09:00:00 GMT',
+    });
+
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { 'If-Modified-Since': 'Mon, 11 May 2026 09:00:00 GMT' },
+      })
+    );
+  });
+
+  it('returns notModified:true when the server responds 304', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 304 });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    const result = await fetchNotifications(octokit, {
+      ifModifiedSince: 'Mon, 11 May 2026 09:00:00 GMT',
+    });
+
+    expect(result).toEqual({
+      notifications: [],
+      lastModified: null,
+      notModified: true,
+    });
+  });
+
+  it('propagates non-304 errors (e.g. 401)', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 401, message: 'Bad credentials' });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await expect(fetchNotifications(octokit)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('clamps perPage to 50', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: [], headers: {} });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await fetchNotifications(octokit, { perPage: 200 });
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({ per_page: 50 })
+    );
+  });
+
+  it('filters out unmappable entries instead of throwing', async () => {
+    const octokit = mockOctokit({
+      activity: {
+        listNotificationsForAuthenticatedUser: vi.fn().mockResolvedValue({
+          data: [
+            rawNotification(),
+            null,
+            rawNotification({ repository: undefined }),
+            'malformed',
+          ],
+          headers: {},
+        }),
+      },
+    });
+
+    const result = await fetchNotifications(octokit);
+    expect(result.notifications).toHaveLength(1);
+  });
+});
+
+describe('markThreadAsRead', () => {
+  it('calls the API with the thread id coerced to number', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: {} });
+    const octokit = mockOctokit({ activity: { markThreadAsRead: fn } });
+
+    await markThreadAsRead(octokit, '42');
+    expect(fn).toHaveBeenCalledWith({ thread_id: 42 });
+  });
+});
+
+describe('markThreadsAsRead', () => {
+  it('returns succeeded/failed split when some calls reject', async () => {
+    const fn = vi.fn().mockImplementation(({ thread_id }: { thread_id: number }) => {
+      if (thread_id === 2) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ data: {} });
+    });
+    const octokit = mockOctokit({ activity: { markThreadAsRead: fn } });
+
+    const result = await markThreadsAsRead(octokit, ['1', '2', '3']);
+    expect(result.succeeded).toEqual(['1', '3']);
+    expect(result.failed).toEqual([{ id: '2', error: 'boom' }]);
+  });
+
+  it('handles an empty list', async () => {
+    const fn = vi.fn();
+    const octokit = mockOctokit({ activity: { markThreadAsRead: fn } });
+    const result = await markThreadsAsRead(octokit, []);
+    expect(result.succeeded).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('markAllAsRead', () => {
+  it('passes last_read_at when before is provided', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: {} });
+    const octokit = mockOctokit({
+      activity: { markNotificationsAsRead: fn },
+    });
+
+    await markAllAsRead(octokit, '2026-05-12T10:00:00Z');
+    expect(fn).toHaveBeenCalledWith({ last_read_at: '2026-05-12T10:00:00Z' });
+  });
+
+  it('omits last_read_at when before is undefined', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: {} });
+    const octokit = mockOctokit({
+      activity: { markNotificationsAsRead: fn },
+    });
+
+    await markAllAsRead(octokit);
+    expect(fn).toHaveBeenCalledWith({});
+  });
+});

--- a/shared/github/notifications.ts
+++ b/shared/github/notifications.ts
@@ -35,7 +35,9 @@ export function mapNotification(raw: unknown): NotificationItem | null {
   const owner = repository?.owner as Record<string, unknown> | undefined;
 
   const id = typeof r.id === 'string' ? r.id : String(r.id ?? '');
-  if (!id) return null;
+  // Thread IDs must be numeric — Number(threadId) inside markThreadAsRead
+  // would silently NaN out on a malformed value otherwise.
+  if (!id || !/^\d+$/.test(id)) return null;
 
   const repoOwner = typeof owner?.login === 'string' ? owner.login : '';
   const repoName = typeof repository?.name === 'string' ? repository.name : '';

--- a/shared/github/notifications.ts
+++ b/shared/github/notifications.ts
@@ -1,0 +1,170 @@
+import type { Octokit } from '@octokit/rest';
+import type {
+  NotificationItem,
+  NotificationReason,
+  NotificationSubjectType,
+} from '../types.js';
+import { parseNotificationSubject } from '../utils/parseNotificationSubject.js';
+
+export interface FetchNotificationsOptions {
+  /** Include already-read threads. Default false. */
+  all?: boolean;
+  /** If set, sent as `If-Modified-Since`. A 304 response is free against the rate limit. */
+  ifModifiedSince?: string | null;
+  /** Page size, max 50 per GitHub's limit. Default 50. */
+  perPage?: number;
+}
+
+export interface FetchNotificationsResult {
+  notifications: NotificationItem[];
+  /** `Last-Modified` from the response, suitable for the next `If-Modified-Since`. */
+  lastModified: string | null;
+  /** True when the server returned 304 (nothing changed). `notifications` will be empty. */
+  notModified: boolean;
+}
+
+/**
+ * Map a raw GitHub notification thread to our internal `NotificationItem`.
+ * Pulled out so it can be reused by tests and future endpoints.
+ */
+export function mapNotification(raw: unknown): NotificationItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const subject = r.subject as Record<string, unknown> | undefined;
+  const repository = r.repository as Record<string, unknown> | undefined;
+  const owner = repository?.owner as Record<string, unknown> | undefined;
+
+  const id = typeof r.id === 'string' ? r.id : String(r.id ?? '');
+  if (!id) return null;
+
+  const repoOwner = typeof owner?.login === 'string' ? owner.login : '';
+  const repoName = typeof repository?.name === 'string' ? repository.name : '';
+  if (!repoOwner || !repoName) return null;
+
+  const subjectUrl = typeof subject?.url === 'string' ? subject.url : null;
+  const parsed = parseNotificationSubject(subjectUrl);
+
+  return {
+    id,
+    unread: r.unread === true,
+    reason: (typeof r.reason === 'string' ? r.reason : 'subscribed') as NotificationReason,
+    updatedAt: typeof r.updated_at === 'string' ? r.updated_at : new Date().toISOString(),
+    lastReadAt: typeof r.last_read_at === 'string' ? r.last_read_at : null,
+    repo: { owner: repoOwner, name: repoName },
+    subject: {
+      title: typeof subject?.title === 'string' ? subject.title : '',
+      type: (typeof subject?.type === 'string' ? subject.type : 'Issue') as NotificationSubjectType,
+      url: subjectUrl,
+      latestCommentUrl:
+        typeof subject?.latest_comment_url === 'string'
+          ? subject.latest_comment_url
+          : null,
+    },
+    subjectNumber: parsed ? parsed.number : null,
+  };
+}
+
+/**
+ * Fetch the authenticated user's notification threads across all repos.
+ *
+ * Sends `If-Modified-Since` when `ifModifiedSince` is provided so that
+ * unchanged inboxes return 304 and do not consume the rate-limit budget.
+ * Octokit surfaces 304 as a thrown error with `status === 304`; we catch
+ * it and return `notModified: true`.
+ */
+export async function fetchNotifications(
+  octokit: Octokit,
+  options: FetchNotificationsOptions = {}
+): Promise<FetchNotificationsResult> {
+  const perPage = Math.max(1, Math.min(options.perPage ?? 50, 50));
+  const headers: Record<string, string> = {};
+  if (options.ifModifiedSince) {
+    headers['If-Modified-Since'] = options.ifModifiedSince;
+  }
+
+  try {
+    const response = await octokit.activity.listNotificationsForAuthenticatedUser({
+      all: options.all ?? false,
+      per_page: perPage,
+      headers,
+    });
+
+    const raw = Array.isArray(response.data) ? response.data : [];
+    const notifications = raw
+      .map((n) => mapNotification(n))
+      .filter((n): n is NotificationItem => n !== null);
+
+    const lastModified =
+      typeof response.headers?.['last-modified'] === 'string'
+        ? response.headers['last-modified']
+        : null;
+
+    return { notifications, lastModified, notModified: false };
+  } catch (e) {
+    if (
+      typeof e === 'object' &&
+      e !== null &&
+      'status' in e &&
+      (e as { status: unknown }).status === 304
+    ) {
+      return { notifications: [], lastModified: null, notModified: true };
+    }
+    throw e;
+  }
+}
+
+/**
+ * Mark a single notification thread as read.
+ */
+export async function markThreadAsRead(
+  octokit: Octokit,
+  threadId: string
+): Promise<void> {
+  await octokit.activity.markThreadAsRead({ thread_id: Number(threadId) });
+}
+
+export interface BulkMarkResult {
+  succeeded: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+/**
+ * Mark many notification threads as read. Uses Promise.allSettled so a
+ * single failure does not abort the bulk operation; partial-failure
+ * counts are surfaced for the UI to display.
+ */
+export async function markThreadsAsRead(
+  octokit: Octokit,
+  threadIds: string[]
+): Promise<BulkMarkResult> {
+  const results = await Promise.allSettled(
+    threadIds.map((id) => markThreadAsRead(octokit, id))
+  );
+  const succeeded: string[] = [];
+  const failed: Array<{ id: string; error: string }> = [];
+  results.forEach((r, i) => {
+    const id = threadIds[i];
+    if (r.status === 'fulfilled') {
+      succeeded.push(id);
+    } else {
+      failed.push({
+        id,
+        error: r.reason instanceof Error ? r.reason.message : 'Unknown error',
+      });
+    }
+  });
+  return { succeeded, failed };
+}
+
+/**
+ * Mark ALL the authenticated user's notifications as read.
+ * `before` is an ISO timestamp; threads updated after it are left unread.
+ */
+export async function markAllAsRead(
+  octokit: Octokit,
+  before?: string
+): Promise<void> {
+  await octokit.activity.markNotificationsAsRead(
+    before ? { last_read_at: before } : {}
+  );
+}

--- a/shared/hooks/useNotificationRules.test.ts
+++ b/shared/hooks/useNotificationRules.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationItem, NotificationRule } from '../types.js';
+import {
+  ruleMatches,
+  notificationsMatchingRule,
+  BUILTIN_PRESETS,
+} from './useNotificationRules.js';
+
+function notification(over: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: '1',
+    unread: true,
+    reason: 'subscribed',
+    updatedAt: '2026-05-12T10:00:00Z',
+    lastReadAt: null,
+    repo: { owner: 'acme', name: 'web' },
+    subject: {
+      title: 'Bump @octokit/rest from 21.0.0 to 21.1.1',
+      type: 'PullRequest',
+      url: 'https://api.github.com/repos/acme/web/pulls/42',
+      latestCommentUrl: null,
+    },
+    subjectNumber: 42,
+    ...over,
+  };
+}
+
+function rule(
+  conditions: NotificationRule['conditions'],
+  over: Partial<NotificationRule> = {}
+): NotificationRule {
+  return {
+    id: 'r1',
+    name: 'test',
+    enabled: true,
+    autoApply: false,
+    conditions,
+    action: 'mark-read',
+    createdAt: '2026-05-12T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('ruleMatches', () => {
+  it('matches title startsWith "Bump "', () => {
+    expect(
+      ruleMatches(
+        rule([{ field: 'title', op: 'startsWith', value: 'Bump ' }]),
+        notification()
+      )
+    ).toBe(true);
+  });
+
+  it('matches reason equals', () => {
+    expect(
+      ruleMatches(
+        rule([{ field: 'reason', op: 'equals', value: 'ci_activity' }]),
+        notification({ reason: 'ci_activity' })
+      )
+    ).toBe(true);
+  });
+
+  it('matches repo equals owner/name', () => {
+    expect(
+      ruleMatches(
+        rule([{ field: 'repo', op: 'equals', value: 'acme/web' }]),
+        notification()
+      )
+    ).toBe(true);
+  });
+
+  it('matches subjectType', () => {
+    expect(
+      ruleMatches(
+        rule([{ field: 'subjectType', op: 'equals', value: 'PullRequest' }]),
+        notification()
+      )
+    ).toBe(true);
+  });
+
+  it('AND-combines multiple conditions', () => {
+    const r = rule([
+      { field: 'title', op: 'startsWith', value: 'Bump ' },
+      { field: 'repo', op: 'equals', value: 'acme/web' },
+    ]);
+    expect(ruleMatches(r, notification())).toBe(true);
+    expect(ruleMatches(r, notification({ repo: { owner: 'x', name: 'y' } }))).toBe(false);
+  });
+
+  it('returns false when conditions list is empty (safety default)', () => {
+    expect(ruleMatches(rule([]), notification())).toBe(false);
+  });
+
+  it('regex op compiles each call without throwing on invalid patterns', () => {
+    expect(
+      ruleMatches(
+        rule([{ field: 'title', op: 'regex', value: '[invalid(' }]),
+        notification()
+      )
+    ).toBe(false);
+  });
+
+  it('uses authorResolver for author field', () => {
+    const r = rule([{ field: 'author', op: 'regex', value: '\\[bot\\]$' }]);
+    const resolver = (_n: NotificationItem) => 'dependabot[bot]';
+    expect(ruleMatches(r, notification(), resolver)).toBe(true);
+  });
+
+  it('author rule does not match when no resolver is provided', () => {
+    const r = rule([{ field: 'author', op: 'equals', value: 'dependabot[bot]' }]);
+    expect(ruleMatches(r, notification())).toBe(false);
+  });
+});
+
+describe('notificationsMatchingRule', () => {
+  it('returns only matching notifications', () => {
+    const items = [
+      notification({ id: '1' }),
+      notification({ id: '2', subject: { ...notification().subject, title: 'Fix bug' } }),
+      notification({ id: '3' }),
+    ];
+    const r = rule([{ field: 'title', op: 'startsWith', value: 'Bump ' }]);
+    const matches = notificationsMatchingRule(r, items);
+    expect(matches.map((n) => n.id)).toEqual(['1', '3']);
+  });
+});
+
+describe('BUILTIN_PRESETS', () => {
+  it('Dependabot bumps preset matches a Bump-titled notification', () => {
+    const preset = BUILTIN_PRESETS.find((p) => p.name === 'Dependabot bumps');
+    expect(preset).toBeDefined();
+    const r = rule(preset!.conditions);
+    expect(ruleMatches(r, notification())).toBe(true);
+  });
+
+  it('Bot threads preset matches a [bot] author via resolver', () => {
+    const preset = BUILTIN_PRESETS.find((p) => p.name === 'Bot threads');
+    expect(preset).toBeDefined();
+    const r = rule(preset!.conditions);
+    const resolver = () => 'github-actions[bot]';
+    expect(ruleMatches(r, notification(), resolver)).toBe(true);
+  });
+
+  it('CI activity preset matches ci_activity reason', () => {
+    const preset = BUILTIN_PRESETS.find((p) => p.name === 'CI activity');
+    expect(preset).toBeDefined();
+    const r = rule(preset!.conditions);
+    expect(ruleMatches(r, notification({ reason: 'ci_activity' }))).toBe(true);
+  });
+});

--- a/shared/hooks/useNotificationRules.ts
+++ b/shared/hooks/useNotificationRules.ts
@@ -145,12 +145,18 @@ export function useNotificationRules({
   const storageRef = useRef(storage);
   storageRef.current = storage;
 
-  // Load
+  // Load. `active` guards against a `storage` swap (or unmount) racing with
+  // the async getItem — without it, a stale resolution could call setRules
+  // after we've already started loading from a new adapter, and the persist
+  // effect below could then write those stale rules back to the new storage.
   useEffect(() => {
+    let active = true;
+    setRulesLoaded(false);
+
     storage
       .getItem(STORAGE_KEYS.NOTIFICATION_RULES)
       .then((raw) => {
-        if (!raw) return;
+        if (!active || !raw) return;
         try {
           const parsed = JSON.parse(raw);
           if (Array.isArray(parsed)) {
@@ -162,17 +168,25 @@ export function useNotificationRules({
                 typeof r.enabled === 'boolean' &&
                 Array.isArray(r.conditions)
             );
-            setRules(valid);
+            if (active) setRules(valid);
           }
         } catch {
           /* corrupted — start fresh */
         }
       })
       .catch(() => {})
-      .finally(() => setRulesLoaded(true));
+      .finally(() => {
+        if (active) setRulesLoaded(true);
+      });
+
+    return () => {
+      active = false;
+    };
   }, [storage]);
 
-  // Persist after the initial async load completes.
+  // Persist after the initial async load completes. `rulesLoaded` is reset
+  // to false at the top of the load effect on a storage swap, so this won't
+  // fire with stale rules against a new adapter before its load finishes.
   useEffect(() => {
     if (!rulesLoaded) return;
     storageRef.current

--- a/shared/hooks/useNotificationRules.ts
+++ b/shared/hooks/useNotificationRules.ts
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  NotificationItem,
+  NotificationRule,
+  RuleCondition,
+} from '../types.js';
+import type { StorageAdapter } from '../storage.js';
+import { STORAGE_KEYS } from '../constants.js';
+
+/**
+ * Built-in rule presets users can materialize as their own saved rules.
+ * Shipping these as data (not hard-coded behavior) lets users edit or
+ * delete them like any other rule.
+ */
+export const BUILTIN_PRESETS: ReadonlyArray<Omit<NotificationRule, 'id' | 'createdAt'>> = [
+  {
+    name: 'Dependabot bumps',
+    enabled: true,
+    autoApply: false,
+    conditions: [
+      { field: 'title', op: 'startsWith', value: 'Bump ' },
+    ],
+    action: 'mark-read',
+  },
+  {
+    name: 'Bot threads',
+    enabled: true,
+    autoApply: false,
+    conditions: [
+      // GitHub bot logins end in `[bot]`. Use a regex op for a precise match.
+      { field: 'author', op: 'regex', value: '\\[bot\\]$' },
+    ],
+    action: 'mark-read',
+  },
+  {
+    name: 'CI activity',
+    enabled: true,
+    autoApply: false,
+    conditions: [
+      { field: 'reason', op: 'equals', value: 'ci_activity' },
+    ],
+    action: 'mark-read',
+  },
+];
+
+function generateId(): string {
+  // Inline UUID-ish id — avoids a runtime dep. Sufficient for local-only rule ids.
+  return `r_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Extract a string value from a notification for a given rule field.
+ *
+ * Some fields (notably `author`) aren't available on the notifications
+ * API response itself — the API does not include the actor. Callers who
+ * want author-matching must pass an `authorResolver` (typically a lookup
+ * into the cross-referenced `items[]` PR object). When unavailable, the
+ * author field falls back to empty string so author rules simply do not
+ * match rather than throwing.
+ */
+function fieldValue(
+  n: NotificationItem,
+  field: RuleCondition['field'],
+  authorResolver?: (n: NotificationItem) => string | null
+): string {
+  switch (field) {
+    case 'title': return n.subject.title;
+    case 'repo': return `${n.repo.owner}/${n.repo.name}`;
+    case 'reason': return n.reason;
+    case 'subjectType': return n.subject.type;
+    case 'author': return authorResolver?.(n) ?? '';
+  }
+}
+
+function evaluateCondition(
+  n: NotificationItem,
+  cond: RuleCondition,
+  authorResolver?: (n: NotificationItem) => string | null
+): boolean {
+  const value = fieldValue(n, cond.field, authorResolver);
+  switch (cond.op) {
+    case 'equals': return value === cond.value;
+    case 'startsWith': return value.startsWith(cond.value);
+    case 'contains': return value.includes(cond.value);
+    case 'regex': {
+      try {
+        return new RegExp(cond.value).test(value);
+      } catch {
+        return false;
+      }
+    }
+  }
+}
+
+/**
+ * Returns true when the notification matches every condition in the rule.
+ * An empty condition list matches nothing (safer than matching everything,
+ * since the only action today is destructive — mark-read).
+ */
+export function ruleMatches(
+  rule: NotificationRule,
+  n: NotificationItem,
+  authorResolver?: (n: NotificationItem) => string | null
+): boolean {
+  if (rule.conditions.length === 0) return false;
+  return rule.conditions.every((c) => evaluateCondition(n, c, authorResolver));
+}
+
+export function notificationsMatchingRule(
+  rule: NotificationRule,
+  notifications: NotificationItem[],
+  authorResolver?: (n: NotificationItem) => string | null
+): NotificationItem[] {
+  return notifications.filter((n) => ruleMatches(rule, n, authorResolver));
+}
+
+interface UseNotificationRulesOptions {
+  storage: StorageAdapter;
+}
+
+interface UseNotificationRulesResult {
+  rules: NotificationRule[];
+  rulesLoaded: boolean;
+  addRule: (input: Omit<NotificationRule, 'id' | 'createdAt'>) => NotificationRule;
+  updateRule: (id: string, patch: Partial<Omit<NotificationRule, 'id' | 'createdAt'>>) => void;
+  deleteRule: (id: string) => void;
+  toggleRule: (id: string) => void;
+  reorderRules: (orderedIds: string[]) => void;
+}
+
+/**
+ * CRUD store for user-defined notification rules. Persists via the
+ * supplied storage adapter under STORAGE_KEYS.NOTIFICATION_RULES.
+ *
+ * Mirrors the async-loaded-before-persist pattern from
+ * useFilteredItems.ts so AsyncStorage on mobile doesn't clobber a
+ * persisted value with the in-memory default before the loader resolves.
+ */
+export function useNotificationRules({
+  storage,
+}: UseNotificationRulesOptions): UseNotificationRulesResult {
+  const [rules, setRules] = useState<NotificationRule[]>([]);
+  const [rulesLoaded, setRulesLoaded] = useState(false);
+
+  const storageRef = useRef(storage);
+  storageRef.current = storage;
+
+  // Load
+  useEffect(() => {
+    storage
+      .getItem(STORAGE_KEYS.NOTIFICATION_RULES)
+      .then((raw) => {
+        if (!raw) return;
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            const valid = parsed.filter(
+              (r): r is NotificationRule =>
+                r != null &&
+                typeof r.id === 'string' &&
+                typeof r.name === 'string' &&
+                typeof r.enabled === 'boolean' &&
+                Array.isArray(r.conditions)
+            );
+            setRules(valid);
+          }
+        } catch {
+          /* corrupted — start fresh */
+        }
+      })
+      .catch(() => {})
+      .finally(() => setRulesLoaded(true));
+  }, [storage]);
+
+  // Persist after the initial async load completes.
+  useEffect(() => {
+    if (!rulesLoaded) return;
+    storageRef.current
+      .setItem(STORAGE_KEYS.NOTIFICATION_RULES, JSON.stringify(rules))
+      .catch(() => {});
+  }, [rules, rulesLoaded]);
+
+  const addRule = useCallback(
+    (input: Omit<NotificationRule, 'id' | 'createdAt'>): NotificationRule => {
+      const rule: NotificationRule = {
+        ...input,
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+      };
+      setRules((prev) => [...prev, rule]);
+      return rule;
+    },
+    []
+  );
+
+  const updateRule = useCallback(
+    (id: string, patch: Partial<Omit<NotificationRule, 'id' | 'createdAt'>>) => {
+      setRules((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, ...patch } : r))
+      );
+    },
+    []
+  );
+
+  const deleteRule = useCallback((id: string) => {
+    setRules((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  const toggleRule = useCallback((id: string) => {
+    setRules((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, enabled: !r.enabled } : r))
+    );
+  }, []);
+
+  const reorderRules = useCallback((orderedIds: string[]) => {
+    setRules((prev) => {
+      const byId = new Map(prev.map((r) => [r.id, r]));
+      const reordered: NotificationRule[] = [];
+      for (const id of orderedIds) {
+        const r = byId.get(id);
+        if (r) reordered.push(r);
+      }
+      // Append any rules not present in orderedIds (defensive).
+      for (const r of prev) {
+        if (!orderedIds.includes(r.id)) reordered.push(r);
+      }
+      return reordered;
+    });
+  }, []);
+
+  return {
+    rules,
+    rulesLoaded,
+    addRule,
+    updateRule,
+    deleteRule,
+    toggleRule,
+    reorderRules,
+  };
+}

--- a/shared/hooks/useNotificationRules.ts
+++ b/shared/hooks/useNotificationRules.ts
@@ -160,14 +160,29 @@ export function useNotificationRules({
         try {
           const parsed = JSON.parse(raw);
           if (Array.isArray(parsed)) {
-            const valid = parsed.filter(
-              (r): r is NotificationRule =>
-                r != null &&
-                typeof r.id === 'string' &&
-                typeof r.name === 'string' &&
-                typeof r.enabled === 'boolean' &&
-                Array.isArray(r.conditions)
-            );
+            const valid = parsed.filter((r): r is NotificationRule => {
+              if (
+                r == null ||
+                typeof r.id !== 'string' ||
+                typeof r.name !== 'string' ||
+                typeof r.enabled !== 'boolean' ||
+                typeof r.autoApply !== 'boolean' ||
+                r.action !== 'mark-read' ||
+                !Array.isArray(r.conditions)
+              ) {
+                return false;
+              }
+              // Every condition needs a fully-typed shape; a corrupted entry
+              // would otherwise cause ruleMatches to throw at evaluation time.
+              return r.conditions.every(
+                (c: unknown) =>
+                  c != null &&
+                  typeof c === 'object' &&
+                  typeof (c as RuleCondition).field === 'string' &&
+                  typeof (c as RuleCondition).op === 'string' &&
+                  typeof (c as RuleCondition).value === 'string'
+              );
+            });
             if (active) setRules(valid);
           }
         } catch {
@@ -229,14 +244,15 @@ export function useNotificationRules({
   const reorderRules = useCallback((orderedIds: string[]) => {
     setRules((prev) => {
       const byId = new Map(prev.map((r) => [r.id, r]));
+      const orderedSet = new Set(orderedIds);
       const reordered: NotificationRule[] = [];
       for (const id of orderedIds) {
         const r = byId.get(id);
         if (r) reordered.push(r);
       }
-      // Append any rules not present in orderedIds (defensive).
+      // Append any rules not present in orderedIds (defensive — O(n) lookup).
       for (const r of prev) {
-        if (!orderedIds.includes(r.id)) reordered.push(r);
+        if (!orderedSet.has(r.id)) reordered.push(r);
       }
       return reordered;
     });

--- a/shared/hooks/useNotifications.ts
+++ b/shared/hooks/useNotifications.ts
@@ -78,6 +78,7 @@ export function useNotifications({
     if (!client || !enabledNow) {
       setNotifications([]);
       setError(null);
+      setAuthError(false);
       setLoading(false);
       return;
     }

--- a/shared/hooks/useNotifications.ts
+++ b/shared/hooks/useNotifications.ts
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Octokit } from '@octokit/rest';
+import type { NotificationItem } from '../types.js';
+import type { StorageAdapter } from '../storage.js';
+import { STORAGE_KEYS } from '../constants.js';
+import {
+  fetchNotifications,
+  markThreadAsRead as apiMarkThreadAsRead,
+  markThreadsAsRead as apiMarkThreadsAsRead,
+  markAllAsRead as apiMarkAllAsRead,
+} from '../github/notifications.js';
+import { isAuthError } from '../github/errors.js';
+
+interface UseNotificationsOptions {
+  octokit: Octokit | null;
+  /** When false, the hook is inert: no fetches, empty result. */
+  enabled: boolean;
+  /** Auto-refresh interval in seconds. 0 disables polling. */
+  refreshIntervalSeconds: number;
+  storage: StorageAdapter;
+}
+
+interface UseNotificationsResult {
+  notifications: NotificationItem[];
+  loading: boolean;
+  error: string | null;
+  authError: boolean;
+  lastRefresh: Date | null;
+  /** Manually trigger a refresh (also resets the auto-refresh countdown). */
+  refresh: () => void;
+  /** Optimistically mark a single thread read; rolls back on error. */
+  markThreadRead: (threadId: string) => Promise<void>;
+  /** Bulk-mark; rolls back any failures. Returns succeeded/failed split. */
+  markThreadsRead: (
+    threadIds: string[]
+  ) => Promise<{ succeeded: string[]; failed: Array<{ id: string; error: string }> }>;
+  /** Mark every thread read on the server and locally. */
+  markAllRead: () => Promise<void>;
+}
+
+/**
+ * Fetch and cache the authenticated user's GitHub notifications.
+ *
+ * Polls on `refreshIntervalSeconds`; sends `If-Modified-Since` so 304
+ * responses are free against the rate-limit budget. Optimistic mutations
+ * keep the UI responsive — failures roll back local state.
+ */
+export function useNotifications({
+  octokit,
+  enabled,
+  refreshIntervalSeconds,
+  storage,
+}: UseNotificationsOptions): UseNotificationsResult {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [authError, setAuthError] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  const octokitRef = useRef(octokit);
+  octokitRef.current = octokit;
+  const storageRef = useRef(storage);
+  storageRef.current = storage;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  const refresh = useCallback(() => {
+    setRefreshCounter((c) => c + 1);
+  }, []);
+
+  // Main fetch effect — runs on mount, on octokit change, and on each refresh tick.
+  useEffect(() => {
+    const client = octokitRef.current;
+    const enabledNow = enabledRef.current;
+    const store = storageRef.current;
+
+    if (!client || !enabledNow) {
+      setNotifications([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setAuthError(false);
+
+    (async () => {
+      try {
+        const ifModifiedSince = await store.getItem(
+          STORAGE_KEYS.NOTIFICATIONS_LAST_MODIFIED
+        );
+
+        const result = await fetchNotifications(client, {
+          ifModifiedSince: ifModifiedSince ?? undefined,
+        });
+
+        if (cancelled) return;
+
+        if (!result.notModified) {
+          setNotifications(result.notifications);
+          if (result.lastModified) {
+            await store
+              .setItem(STORAGE_KEYS.NOTIFICATIONS_LAST_MODIFIED, result.lastModified)
+              .catch(() => {});
+          }
+        }
+
+        setLastRefresh(new Date());
+      } catch (e) {
+        if (cancelled) return;
+        if (isAuthError(e)) {
+          setAuthError(true);
+        } else {
+          setError(e instanceof Error ? e.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [octokit, refreshCounter, enabled]);
+
+  // Auto-refresh via setInterval. Lives inside this hook (rather than
+  // composing useAutoRefresh) so we don't surface a separate
+  // countdown UI for notifications.
+  useEffect(() => {
+    if (!enabled || refreshIntervalSeconds <= 0) return;
+    const id = setInterval(() => {
+      setRefreshCounter((c) => c + 1);
+    }, refreshIntervalSeconds * 1000);
+    return () => clearInterval(id);
+  }, [enabled, refreshIntervalSeconds]);
+
+  const markThreadRead = useCallback(
+    async (threadId: string) => {
+      const client = octokitRef.current;
+      if (!client) return;
+
+      let previousSnapshot: NotificationItem[] | null = null;
+      setNotifications((prev) => {
+        previousSnapshot = prev;
+        return prev.map((n) =>
+          n.id === threadId ? { ...n, unread: false } : n
+        );
+      });
+
+      try {
+        await apiMarkThreadAsRead(client, threadId);
+      } catch (e) {
+        if (previousSnapshot) setNotifications(previousSnapshot);
+        if (isAuthError(e)) setAuthError(true);
+        else setError(e instanceof Error ? e.message : 'Unknown error');
+      }
+    },
+    []
+  );
+
+  const markThreadsRead = useCallback(
+    async (threadIds: string[]) => {
+      const client = octokitRef.current;
+      if (!client || threadIds.length === 0) {
+        return { succeeded: [], failed: [] };
+      }
+
+      const ids = new Set(threadIds);
+      let previousSnapshot: NotificationItem[] | null = null;
+      setNotifications((prev) => {
+        previousSnapshot = prev;
+        return prev.map((n) => (ids.has(n.id) ? { ...n, unread: false } : n));
+      });
+
+      try {
+        const result = await apiMarkThreadsAsRead(client, threadIds);
+        if (result.failed.length > 0) {
+          const failedIds = new Set(result.failed.map((f) => f.id));
+          // Roll back only the entries that actually failed.
+          setNotifications((prev) =>
+            prev.map((n) => {
+              if (!failedIds.has(n.id)) return n;
+              const original = previousSnapshot?.find((p) => p.id === n.id);
+              return original ?? n;
+            })
+          );
+        }
+        return result;
+      } catch (e) {
+        if (previousSnapshot) setNotifications(previousSnapshot);
+        if (isAuthError(e)) setAuthError(true);
+        else setError(e instanceof Error ? e.message : 'Unknown error');
+        return { succeeded: [], failed: threadIds.map((id) => ({ id, error: 'request-failed' })) };
+      }
+    },
+    []
+  );
+
+  const markAllRead = useCallback(async () => {
+    const client = octokitRef.current;
+    if (!client) return;
+
+    let previousSnapshot: NotificationItem[] | null = null;
+    setNotifications((prev) => {
+      previousSnapshot = prev;
+      return prev.map((n) => ({ ...n, unread: false }));
+    });
+
+    try {
+      await apiMarkAllAsRead(client);
+    } catch (e) {
+      if (previousSnapshot) setNotifications(previousSnapshot);
+      if (isAuthError(e)) setAuthError(true);
+      else setError(e instanceof Error ? e.message : 'Unknown error');
+    }
+  }, []);
+
+  return {
+    notifications,
+    loading,
+    error,
+    authError,
+    lastRefresh,
+    refresh,
+    markThreadRead,
+    markThreadsRead,
+    markAllRead,
+  };
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -12,6 +12,9 @@ export interface Config {
     maxPrsPerRepo: number;
     autoRefreshInterval: number; // seconds, 0 = disabled
     staleDays: number; // days of inactivity before an item is considered stale
+    notificationsEnabled: boolean;
+    notificationsRefreshInterval: number; // seconds, 0 = disabled. Polled independently of PRs.
+    highlightWorkingSet: boolean; // emphasize notifications tied to PRs the user authored / is reviewing
   };
 }
 
@@ -21,7 +24,7 @@ export type SortDirection = 'asc' | 'desc';
 export type FilterMode = 'all' | 'failing' | 'needs-review' | 'review-requested' | 'new-activity' | 'merge-ready' | 'stale';
 export type ItemTypeFilter = 'both' | 'prs' | 'issues';
 export type OwnershipFilter = 'everyone' | 'created' | 'assigned' | 'involved';
-export type ViewMode = 'list' | 'repos' | 'help' | 'detail';
+export type ViewMode = 'list' | 'repos' | 'help' | 'detail' | 'notifications' | 'notification-rules';
 export type ThemeMode = 'dark' | 'light' | 'system';
 
 export interface RepoFetchError {
@@ -156,4 +159,77 @@ export interface PRDetail {
   headBranch: string;
   baseBranch: string;
   timeline: TimelineEvent[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Notifications
+
+export type NotificationSubjectType =
+  | 'PullRequest'
+  | 'Issue'
+  | 'Commit'
+  | 'Release'
+  | 'Discussion'
+  | 'CheckSuite'
+  | 'RepositoryVulnerabilityAlert'
+  | 'RepositoryDependabotAlertsThread'
+  | 'WorkflowRun';
+
+export type NotificationReason =
+  | 'assign'
+  | 'author'
+  | 'comment'
+  | 'ci_activity'
+  | 'invitation'
+  | 'manual'
+  | 'mention'
+  | 'review_requested'
+  | 'security_alert'
+  | 'state_change'
+  | 'subscribed'
+  | 'team_mention'
+  | 'approval_requested'
+  | 'member_feature_requested';
+
+export interface NotificationItem {
+  /** GitHub thread ID (string in the API). */
+  id: string;
+  unread: boolean;
+  reason: NotificationReason;
+  updatedAt: string;
+  lastReadAt: string | null;
+  repo: { owner: string; name: string };
+  subject: {
+    title: string;
+    type: NotificationSubjectType;
+    /** API URL of the subject, or null for some subject types. */
+    url: string | null;
+    latestCommentUrl: string | null;
+  };
+  /** PR/issue number parsed from `subject.url`. Null when the URL isn't a PR/issue. */
+  subjectNumber: number | null;
+}
+
+export type RuleField = 'title' | 'author' | 'repo' | 'reason' | 'subjectType';
+export type RuleOp = 'startsWith' | 'equals' | 'contains' | 'regex';
+
+export interface RuleCondition {
+  field: RuleField;
+  op: RuleOp;
+  value: string;
+}
+
+export interface NotificationRule {
+  /** UUID-like string; generated locally on rule creation. */
+  id: string;
+  /** User-facing label. */
+  name: string;
+  enabled: boolean;
+  /** When true, the rule's matching threads are auto-marked-read after each refresh. */
+  autoApply: boolean;
+  /** All conditions must match (AND). An empty list matches nothing. */
+  conditions: RuleCondition[];
+  /** Action to apply to matching notifications. Only mark-read in v1. */
+  action: 'mark-read';
+  createdAt: string;
 }

--- a/shared/utils/notificationMatch.test.ts
+++ b/shared/utils/notificationMatch.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  DashboardItem,
+  NotificationItem,
+  PRItem,
+  IssueItem,
+} from '../types.js';
+import {
+  matchNotifications,
+  notificationsByItemKey,
+  itemKey,
+} from './notificationMatch.js';
+
+function pr(over: Partial<PRItem> = {}): PRItem {
+  return {
+    kind: 'pr',
+    id: 1,
+    number: 42,
+    title: 'PR',
+    author: 'someone-else',
+    repo: { owner: 'acme', name: 'web' },
+    url: 'https://github.com/acme/web/pull/42',
+    updatedAt: '2026-05-12T10:00:00Z',
+    createdAt: '2026-05-11T10:00:00Z',
+    ciStatus: 'none',
+    reviewState: { approvals: 0, changesRequested: 0, commentCount: 0 },
+    draft: false,
+    state: 'open',
+    isRequestedReviewer: false,
+    assignees: [],
+    labels: [],
+    ...over,
+  };
+}
+
+function issue(over: Partial<IssueItem> = {}): IssueItem {
+  return {
+    kind: 'issue',
+    id: 100,
+    number: 99,
+    title: 'Issue',
+    author: 'someone-else',
+    repo: { owner: 'acme', name: 'web' },
+    url: 'https://github.com/acme/web/issues/99',
+    updatedAt: '2026-05-12T10:00:00Z',
+    createdAt: '2026-05-11T10:00:00Z',
+    state: 'open',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    ...over,
+  };
+}
+
+function notification(over: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: '1',
+    unread: true,
+    reason: 'subscribed',
+    updatedAt: '2026-05-12T10:00:00Z',
+    lastReadAt: null,
+    repo: { owner: 'acme', name: 'web' },
+    subject: {
+      title: 'Bump foo',
+      type: 'PullRequest',
+      url: 'https://api.github.com/repos/acme/web/pulls/42',
+      latestCommentUrl: null,
+    },
+    subjectNumber: 42,
+    ...over,
+  };
+}
+
+describe('matchNotifications', () => {
+  it('returns item:null and isWorkingSet:false when subjectNumber is null', () => {
+    const result = matchNotifications(
+      [notification({ subjectNumber: null })],
+      [pr()],
+      'me'
+    );
+    expect(result[0].item).toBeNull();
+    expect(result[0].isWorkingSet).toBe(false);
+  });
+
+  it('matches by owner/repo/number case-insensitively on repo', () => {
+    const items: DashboardItem[] = [pr({ repo: { owner: 'Acme', name: 'Web' } })];
+    const result = matchNotifications([notification()], items, null);
+    expect(result[0].item).toBe(items[0]);
+  });
+
+  it('returns isWorkingSet=true when authUser authored the PR', () => {
+    const result = matchNotifications(
+      [notification()],
+      [pr({ author: 'me' })],
+      'me'
+    );
+    expect(result[0].isWorkingSet).toBe(true);
+  });
+
+  it('returns isWorkingSet=true when authUser is a requested reviewer', () => {
+    const result = matchNotifications(
+      [notification()],
+      [pr({ isRequestedReviewer: true })],
+      'me'
+    );
+    expect(result[0].isWorkingSet).toBe(true);
+  });
+
+  it('returns isWorkingSet=true when authUser is assigned', () => {
+    const result = matchNotifications(
+      [notification()],
+      [pr({ assignees: ['me'] })],
+      'me'
+    );
+    expect(result[0].isWorkingSet).toBe(true);
+  });
+
+  it('returns isWorkingSet=false when authUser is null even if the PR matches', () => {
+    const result = matchNotifications(
+      [notification()],
+      [pr({ author: 'me' })],
+      null
+    );
+    expect(result[0].isWorkingSet).toBe(false);
+  });
+
+  it('does not treat issue matches as working-set (PRs only)', () => {
+    const result = matchNotifications(
+      [
+        notification({
+          subject: {
+            title: 'Issue mention',
+            type: 'Issue',
+            url: 'https://api.github.com/repos/acme/web/issues/99',
+            latestCommentUrl: null,
+          },
+          subjectNumber: 99,
+        }),
+      ],
+      [issue({ author: 'me' })],
+      'me'
+    );
+    expect(result[0].item).toBeDefined();
+    expect(result[0].isWorkingSet).toBe(false);
+  });
+
+  it('returns item:null when nothing matches', () => {
+    const result = matchNotifications(
+      [notification()],
+      [pr({ number: 999 })],
+      'me'
+    );
+    expect(result[0].item).toBeNull();
+  });
+});
+
+describe('notificationsByItemKey', () => {
+  it('groups notifications by their PR/issue key', () => {
+    const a = notification({ id: 'a' });
+    const b = notification({ id: 'b' });
+    const c = notification({ id: 'c', subjectNumber: 100 });
+    const map = notificationsByItemKey([a, b, c]);
+    expect(map.get('acme/web#42')).toHaveLength(2);
+    expect(map.get('acme/web#100')).toHaveLength(1);
+  });
+
+  it('omits notifications without a subjectNumber', () => {
+    const map = notificationsByItemKey([notification({ subjectNumber: null })]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('itemKey', () => {
+  it('lowercases the repo segment', () => {
+    expect(itemKey(pr({ repo: { owner: 'Acme', name: 'Web' }, number: 42 }))).toBe(
+      'acme/web#42'
+    );
+  });
+});

--- a/shared/utils/notificationMatch.ts
+++ b/shared/utils/notificationMatch.ts
@@ -1,0 +1,100 @@
+import type { DashboardItem, NotificationItem, PRItem } from '../types.js';
+
+export interface NotificationMatch {
+  notification: NotificationItem;
+  /** The PR/issue from items[] that the notification points to, when present. */
+  item: DashboardItem | null;
+  /**
+   * True when `item` is a PR the authenticated user is actively working on:
+   *   - authored it
+   *   - is a requested reviewer
+   *   - is assigned
+   * Issues and unmatched notifications are always `false`.
+   */
+  isWorkingSet: boolean;
+}
+
+function buildItemKey(owner: string, repo: string, number: number): string {
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}#${number}`;
+}
+
+function isWorkingSetPR(pr: PRItem, authUser: string): boolean {
+  return (
+    pr.author === authUser ||
+    pr.isRequestedReviewer ||
+    pr.assignees.includes(authUser)
+  );
+}
+
+/**
+ * Cross-reference each notification against the currently-fetched
+ * `items[]`. The lookup is O(1) per notification: items are keyed by
+ * `${owner}/${repo}#${number}` once up front.
+ *
+ * Matching is case-insensitive on the repo segment because GitHub
+ * routes are case-insensitive there, and the notifications API
+ * sometimes returns canonical casing that differs from what the user
+ * typed when adding the repo to LandinGit.
+ */
+export function matchNotifications(
+  notifications: NotificationItem[],
+  items: DashboardItem[],
+  authUser: string | null
+): NotificationMatch[] {
+  const itemIndex = new Map<string, DashboardItem>();
+  for (const item of items) {
+    itemIndex.set(
+      buildItemKey(item.repo.owner, item.repo.name, item.number),
+      item
+    );
+  }
+
+  return notifications.map((notification) => {
+    const number = notification.subjectNumber;
+    if (number == null) {
+      return { notification, item: null, isWorkingSet: false };
+    }
+    const key = buildItemKey(
+      notification.repo.owner,
+      notification.repo.name,
+      number
+    );
+    const item = itemIndex.get(key) ?? null;
+    const isWorkingSet =
+      authUser != null &&
+      item != null &&
+      item.kind === 'pr' &&
+      isWorkingSetPR(item, authUser);
+    return { notification, item, isWorkingSet };
+  });
+}
+
+/**
+ * Group notifications by their matching PR/issue id, for cross-linking
+ * back into the PR table. Returns a Map keyed by `${owner}/${repo}#${number}`
+ * to a list of notifications.
+ */
+export function notificationsByItemKey(
+  notifications: NotificationItem[]
+): Map<string, NotificationItem[]> {
+  const map = new Map<string, NotificationItem[]>();
+  for (const n of notifications) {
+    if (n.subjectNumber == null) continue;
+    const key = buildItemKey(n.repo.owner, n.repo.name, n.subjectNumber);
+    const list = map.get(key);
+    if (list) {
+      list.push(n);
+    } else {
+      map.set(key, [n]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Build the key for an existing DashboardItem so callers can look it up
+ * in the map returned by `notificationsByItemKey`.
+ */
+export function itemKey(item: DashboardItem): string {
+  return buildItemKey(item.repo.owner, item.repo.name, item.number);
+}

--- a/shared/utils/parseNotificationSubject.test.ts
+++ b/shared/utils/parseNotificationSubject.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { parseNotificationSubject } from './parseNotificationSubject.js';
+
+describe('parseNotificationSubject', () => {
+  it('parses a PR subject URL', () => {
+    expect(
+      parseNotificationSubject(
+        'https://api.github.com/repos/acme/web/pulls/42'
+      )
+    ).toEqual({ owner: 'acme', repo: 'web', number: 42, type: 'pull' });
+  });
+
+  it('parses an issue subject URL', () => {
+    expect(
+      parseNotificationSubject(
+        'https://api.github.com/repos/WordPress/gutenberg/issues/12345'
+      )
+    ).toEqual({
+      owner: 'WordPress',
+      repo: 'gutenberg',
+      number: 12345,
+      type: 'issue',
+    });
+  });
+
+  it('returns null for null / undefined / empty input', () => {
+    expect(parseNotificationSubject(null)).toBeNull();
+    expect(parseNotificationSubject(undefined)).toBeNull();
+    expect(parseNotificationSubject('')).toBeNull();
+  });
+
+  it('returns null for non-PR/issue subject URLs (commit, release, etc.)', () => {
+    expect(
+      parseNotificationSubject(
+        'https://api.github.com/repos/acme/web/commits/abc123'
+      )
+    ).toBeNull();
+    expect(
+      parseNotificationSubject(
+        'https://api.github.com/repos/acme/web/releases/1'
+      )
+    ).toBeNull();
+  });
+
+  it('returns null for HTML URLs (we only expect API URLs from notifications)', () => {
+    expect(
+      parseNotificationSubject('https://github.com/acme/web/pull/42')
+    ).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(parseNotificationSubject('not a url')).toBeNull();
+    expect(parseNotificationSubject('https://api.github.com/repos/foo')).toBeNull();
+    expect(
+      parseNotificationSubject('https://api.github.com/repos/acme/web/pulls/notanumber')
+    ).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(
+      parseNotificationSubject('  https://api.github.com/repos/acme/web/pulls/1  ')
+    ).toEqual({ owner: 'acme', repo: 'web', number: 1, type: 'pull' });
+  });
+});

--- a/shared/utils/parseNotificationSubject.ts
+++ b/shared/utils/parseNotificationSubject.ts
@@ -1,0 +1,38 @@
+/**
+ * Parse a GitHub notification's `subject.url` (an API URL) into a stable
+ * identifier we can cross-reference against fetched PRs/issues.
+ *
+ * Notifications return API URLs, not HTML URLs:
+ *   - PRs:    https://api.github.com/repos/{owner}/{repo}/pulls/{number}
+ *   - Issues: https://api.github.com/repos/{owner}/{repo}/issues/{number}
+ *
+ * Other subject types (CheckSuite, Release, Discussion, Commit) either
+ * carry non-matching URLs or `null`; we return `null` for those.
+ */
+export interface ParsedNotificationSubject {
+  owner: string;
+  repo: string;
+  number: number;
+  /** 'pull' for PR subjects, 'issue' for issue subjects. */
+  type: 'pull' | 'issue';
+}
+
+const SUBJECT_URL_RE =
+  /^https?:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/(pulls|issues)\/(\d+)$/;
+
+export function parseNotificationSubject(
+  url: string | null | undefined
+): ParsedNotificationSubject | null {
+  if (!url) return null;
+  const match = SUBJECT_URL_RE.exec(url.trim());
+  if (!match) return null;
+  const [, owner, repo, kind, num] = match;
+  const number = Number(num);
+  if (!Number.isFinite(number)) return null;
+  return {
+    owner,
+    repo,
+    number,
+    type: kind === 'pulls' ? 'pull' : 'issue',
+  };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -15,13 +15,25 @@ describe('loadConfig / saveConfig', () => {
       maxPrsPerRepo: 30,
       autoRefreshInterval: 300,
       staleDays: 14,
+      notificationsEnabled: true,
+      notificationsRefreshInterval: 60,
+      highlightWorkingSet: true,
     });
   });
 
   it('round-trips config through save and load', () => {
     const config = {
       repos: [{ owner: 'acme', name: 'app', enabled: true }],
-      defaults: { sort: 'created' as const, filter: 'failing' as const, maxPrsPerRepo: 50, autoRefreshInterval: 120, staleDays: 14 },
+      defaults: {
+        sort: 'created' as const,
+        filter: 'failing' as const,
+        maxPrsPerRepo: 50,
+        autoRefreshInterval: 120,
+        staleDays: 14,
+        notificationsEnabled: false,
+        notificationsRefreshInterval: 120,
+        highlightWorkingSet: false,
+      },
     };
     saveConfig(config);
     const loaded = loadConfig();
@@ -38,7 +50,16 @@ describe('loadConfig / saveConfig', () => {
   it('merges partial defaults with default values', () => {
     saveConfig({
       repos: [{ owner: 'a', name: 'b', enabled: true }],
-      defaults: { sort: 'repo', filter: 'all', maxPrsPerRepo: 30, autoRefreshInterval: 300, staleDays: 14 },
+      defaults: {
+        sort: 'repo',
+        filter: 'all',
+        maxPrsPerRepo: 30,
+        autoRefreshInterval: 300,
+        staleDays: 14,
+        notificationsEnabled: true,
+        notificationsRefreshInterval: 60,
+        highlightWorkingSet: true,
+      },
     });
     // Simulate a stored config that is missing some defaults
     const stored = JSON.parse(localStorage.getItem('gh-dashboard-config')!);

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,9 @@ const DEFAULT_CONFIG: Config = {
     maxPrsPerRepo: 30,
     autoRefreshInterval: 300,
     staleDays: 14,
+    notificationsEnabled: true,
+    notificationsRefreshInterval: 60,
+    highlightWorkingSet: true,
   },
 };
 


### PR DESCRIPTION
First slice of the GitHub notifications integration tracked in #136 — pure foundations, no user-visible UI change.

## What's here

- **Types** (`shared/types.ts`): `NotificationItem`, `NotificationRule`, `NotificationReason`, `NotificationSubjectType`, `RuleField`, `RuleOp`, `RuleCondition`. Extended `ViewMode` with `notifications` and `notification-rules` modal states. Extended `Config.defaults` with `notificationsEnabled`, `notificationsRefreshInterval` (60s default — pairs well with the rate-limit-free 304 cadence), and `highlightWorkingSet`.
- **Constants** (`shared/constants.ts`): new storage keys `NOTIFICATION_RULES` and `NOTIFICATIONS_LAST_MODIFIED`.
- **GitHub API client** (`shared/github/notifications.ts`): `fetchNotifications` (with `If-Modified-Since` so 304s are free against the rate limit), `markThreadAsRead`, `markThreadsAsRead` (`Promise.allSettled` — surfaces per-thread failures), `markAllAsRead`, and `mapNotification` exported for test reuse.
- **Cross-reference utilities** (`shared/utils/`):
  - `parseNotificationSubject` — extracts `{owner, repo, number, type}` from a notification's API URL.
  - `notificationMatch` — O(1) lookup of notifications against fetched `items[]` via an indexed Map, plus the working-set predicate (author / requested reviewer / assignee).
- **Hooks** (`shared/hooks/`):
  - `useNotifications` — mirrors the streaming/cancellation pattern from `useGithubData`. Propagates 401 to the existing auth-error flow. Optimistic mark-read with rollback. Polls on `refreshIntervalSeconds`.
  - `useNotificationRules` — CRUD over user-defined rules; persists via the `StorageAdapter`; ships `BUILTIN_PRESETS` (Dependabot bumps, Bot threads, CI activity). Includes a pure rule evaluator (`ruleMatches`).

## What's not here yet

No UI — that comes in Phase 2 (`NotificationsView`) and Phase 3 (PR table indicator). This PR is mechanical scaffolding only; nothing renders.

## Verification

- `npm test` — **315 passing** (was 267 before; 48 new tests covering the parser, matcher, fetch module, mark-read calls, 304 path, rule evaluator, and presets).
- `npm run build` — clean TypeScript build.

## Closes / refs

Refs #136. The full plan, decisions, and phasing live in that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub notifications: dedicated view, polling with configurable refresh interval, client-side caching, and optimistic mark-read actions.
  * Configurable notification rules with built-in presets to filter/organize by author, repo, reason, and subject type.
  * Working-set highlighting for items where you’re author, reviewer, or assignee.
* **Chores**
  * Added notification-related defaults to app configuration.
* **Tests**
  * Comprehensive test suites for notification parsing, matching, rules, and GitHub API handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/landingit/pull/137)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->