### PR TITLE
Phase 2: web NotificationsView with header entry and bulk mark-read

### DIFF
--- a/shared/utils/notificationHtmlUrl.test.ts
+++ b/shared/utils/notificationHtmlUrl.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationItem } from '../types.js';
+import { notificationHtmlUrl } from './notificationHtmlUrl.js';
+
+function notification(over: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: '1',
+    unread: true,
+    reason: 'subscribed',
+    updatedAt: '2026-05-12T10:00:00Z',
+    lastReadAt: null,
+    repo: { owner: 'acme', name: 'web' },
+    subject: {
+      title: 'PR',
+      type: 'PullRequest',
+      url: 'https://api.github.com/repos/acme/web/pulls/42',
+      latestCommentUrl: null,
+    },
+    subjectNumber: 42,
+    ...over,
+  };
+}
+
+describe('notificationHtmlUrl', () => {
+  it('translates a PR API URL to github.com/.../pull/N', () => {
+    expect(notificationHtmlUrl(notification())).toBe(
+      'https://github.com/acme/web/pull/42'
+    );
+  });
+
+  it('keeps issues at /issues/', () => {
+    expect(
+      notificationHtmlUrl(
+        notification({
+          subject: {
+            title: 'Issue',
+            type: 'Issue',
+            url: 'https://api.github.com/repos/acme/web/issues/99',
+            latestCommentUrl: null,
+          },
+        })
+      )
+    ).toBe('https://github.com/acme/web/issues/99');
+  });
+
+  it('translates /commits/SHA to /commit/SHA (singular)', () => {
+    expect(
+      notificationHtmlUrl(
+        notification({
+          subject: {
+            title: 'Commit',
+            type: 'Commit',
+            url: 'https://api.github.com/repos/acme/web/commits/abc123',
+            latestCommentUrl: null,
+          },
+        })
+      )
+    ).toBe('https://github.com/acme/web/commit/abc123');
+  });
+
+  it('falls back to the repo page when subject.url is null', () => {
+    expect(
+      notificationHtmlUrl(notification({ subject: { ...notification().subject, url: null } }))
+    ).toBe('https://github.com/acme/web');
+  });
+
+  it('falls back to the repo page on unknown subject URL shapes', () => {
+    expect(
+      notificationHtmlUrl(
+        notification({
+          subject: {
+            title: 'Workflow',
+            type: 'WorkflowRun',
+            url: 'https://api.github.com/repos/acme/web/actions/runs/123',
+            latestCommentUrl: null,
+          },
+        })
+      )
+    ).toBe('https://github.com/acme/web');
+  });
+});

--- a/shared/utils/notificationHtmlUrl.ts
+++ b/shared/utils/notificationHtmlUrl.ts
@@ -1,0 +1,32 @@
+import type { NotificationItem } from '../types.js';
+
+/**
+ * Translate a notification's API subject URL into the equivalent
+ * github.com HTML URL so the user can click through to read the thread.
+ *
+ *   /repos/{owner}/{repo}/pulls/{n}   → /{owner}/{repo}/pull/{n}
+ *   /repos/{owner}/{repo}/issues/{n}  → /{owner}/{repo}/issues/{n}
+ *   /repos/{owner}/{repo}/commits/SHA → /{owner}/{repo}/commit/SHA
+ *
+ * Falls back to the repo URL when the subject URL isn't a known shape,
+ * and to github.com when there's no repo info at all. Never returns
+ * an empty string — callers can always pass the result to window.open.
+ */
+export function notificationHtmlUrl(n: NotificationItem): string {
+  const repoBase = `https://github.com/${n.repo.owner}/${n.repo.name}`;
+  const url = n.subject.url;
+  if (!url) return repoBase;
+
+  const match = /^https?:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/.exec(
+    url
+  );
+  if (!match) return repoBase;
+  const [, owner, repo, kind, rest] = match;
+  switch (kind) {
+    case 'pulls':   return `https://github.com/${owner}/${repo}/pull/${rest}`;
+    case 'issues':  return `https://github.com/${owner}/${repo}/issues/${rest}`;
+    case 'commits': return `https://github.com/${owner}/${repo}/commit/${rest}`;
+    case 'releases': return `https://github.com/${owner}/${repo}/releases/tag/${rest}`;
+    default:        return repoBase;
+  }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,8 @@ import { useLastSeen } from './hooks/useLastSeen.js';
 import { useFilteredItems } from './hooks/useFilteredItems.js';
 import { useModalState } from './hooks/useModalState.js';
 import { useColumnSettings } from './hooks/useColumnSettings.js';
+import { useNotifications } from '../shared/hooks/useNotifications.js';
+import { webStorage } from './storage/webStorage.js';
 import { Header } from './components/Header.js';
 import { FilterBar } from './components/FilterBar.js';
 import { PRTable } from './components/PRTable.js';
@@ -22,6 +24,7 @@ import { RepoManager } from './components/RepoManager.js';
 import { TokenSetup } from './components/TokenSetup.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { DetailPanel } from './components/DetailPanel.js';
+import { NotificationsView } from './components/NotificationsView.js';
 
 const OWNERSHIP_CYCLE: OwnershipFilter[] = ['created', 'assigned', 'involved', 'everyone'];
 
@@ -41,8 +44,8 @@ export function App() {
   const { visibleColumns, columnOrder, toggleColumn, reorderColumns, resetColumns } = useColumnSettings();
 
   const {
-    viewMode, setViewMode, previewItem, isModalOpen,
-    openDetail, closeDetail, openRepos, closeModal,
+    viewMode, setViewMode, previewItem, notificationsPinnedItem, isModalOpen,
+    openDetail, closeDetail, openRepos, openNotifications, closeModal,
   } = useModalState();
 
   const handleRateLimit = useCallback((rl: RateLimit) => setRateLimit(rl), []);
@@ -134,6 +137,43 @@ export function App() {
     paused: isModalOpen,
     onRefresh: refresh,
   });
+
+  const {
+    notifications,
+    loading: notificationsLoading,
+    error: notificationsError,
+    authError: notificationsAuthError,
+    lastRefresh: notificationsLastRefresh,
+    refresh: refreshNotifications,
+    markThreadRead,
+    markThreadsRead,
+  } = useNotifications({
+    octokit,
+    enabled: config.defaults.notificationsEnabled,
+    refreshIntervalSeconds: config.defaults.notificationsRefreshInterval,
+    storage: webStorage,
+  });
+
+  const notificationsUnreadCount = useMemo(
+    () => notifications.filter((n) => n.unread).length,
+    [notifications]
+  );
+
+  // Treat a 401 from notifications the same as a 401 from the main fetch.
+  useEffect(() => {
+    if (notificationsAuthError) handleInvalidToken();
+  }, [notificationsAuthError, handleInvalidToken]);
+
+  const jumpToItem = useCallback(
+    (item: DashboardItem) => {
+      const idx = filtered.findIndex(
+        (f) => f.kind === item.kind && f.id === item.id
+      );
+      if (idx !== -1) setCursorIndex(idx);
+      closeModal();
+    },
+    [filtered, setCursorIndex, closeModal]
+  );
 
   const handleRefresh = useCallback(() => {
     refresh();
@@ -255,7 +295,9 @@ export function App() {
         repoCount={enabledRepos.length}
         itemCount={filtered.length}
         unseenCount={unseenCount}
+        notificationsUnreadCount={notificationsUnreadCount}
         onOpenRepos={openRepos}
+        onOpenNotifications={() => openNotifications()}
         onSignOut={handleSignOut}
         onRefresh={handleRefresh}
         autoRefreshSecondsLeft={autoRefreshSecondsLeft}
@@ -322,6 +364,22 @@ export function App() {
           item={previewItem}
           octokit={octokit}
           onClose={closeDetail}
+        />
+      )}
+      {viewMode === 'notifications' && (
+        <NotificationsView
+          notifications={notifications}
+          loading={notificationsLoading}
+          error={notificationsError}
+          lastRefresh={notificationsLastRefresh}
+          items={items}
+          authUser={username}
+          onClose={closeModal}
+          onRefresh={refreshNotifications}
+          onMarkRead={markThreadRead}
+          onMarkManyRead={markThreadsRead}
+          onJumpToItem={jumpToItem}
+          pinnedItem={notificationsPinnedItem}
         />
       )}
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,9 @@ interface HeaderProps {
   repoCount: number;
   itemCount: number;
   unseenCount: number;
+  notificationsUnreadCount: number;
   onOpenRepos: () => void;
+  onOpenNotifications: () => void;
   onSignOut: () => void;
   onRefresh: () => void;
   autoRefreshSecondsLeft: number | null;
@@ -27,7 +29,9 @@ export function Header({
   repoCount,
   itemCount,
   unseenCount,
+  notificationsUnreadCount,
   onOpenRepos,
+  onOpenNotifications,
   onSignOut,
   onRefresh,
   autoRefreshSecondsLeft,
@@ -69,6 +73,18 @@ export function Header({
           aria-label="Refresh data"
         >
           {loading ? <span className="spinner" /> : '↻'}
+        </button>
+        <button
+          className="header-btn"
+          onClick={onOpenNotifications}
+          title="Open notifications (n)"
+        >
+          Notifications
+          {notificationsUnreadCount > 0 && (
+            <span className="notifications-trigger-badge">
+              {notificationsUnreadCount > 99 ? '99+' : notificationsUnreadCount}
+            </span>
+          )}
         </button>
         <button className="header-btn" onClick={onOpenRepos} title="Manage repos (c)">
           Repos

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import type { NotificationItem, DashboardItem } from '../../shared/types.js';
+import { timeAgo } from '../../shared/utils/timeAgo.js';
+import { notificationHtmlUrl } from '../../shared/utils/notificationHtmlUrl.js';
+
+interface NotificationRowProps {
+  notification: NotificationItem;
+  /** Matched PR/issue from items[], if any. */
+  matchedItem: DashboardItem | null;
+  /** Working-set highlight (authored / requested reviewer / assigned). */
+  isWorkingSet: boolean;
+  /** Multi-select state and toggle. */
+  selected: boolean;
+  onToggleSelected: (id: string) => void;
+  /** Per-row actions. */
+  onMarkRead: (id: string) => void;
+  onJumpToItem: ((item: DashboardItem) => void) | null;
+}
+
+function subjectIcon(type: NotificationItem['subject']['type']): string {
+  switch (type) {
+    case 'PullRequest':              return '⇄';
+    case 'Issue':                    return '●';
+    case 'Commit':                   return '◆';
+    case 'Release':                  return '◈';
+    case 'Discussion':               return '✿';
+    case 'CheckSuite':
+    case 'WorkflowRun':              return '⚙';
+    case 'RepositoryVulnerabilityAlert':
+    case 'RepositoryDependabotAlertsThread': return '⚠';
+    default:                         return '○';
+  }
+}
+
+function reasonLabel(reason: NotificationItem['reason']): string {
+  switch (reason) {
+    case 'review_requested': return 'review requested';
+    case 'ci_activity':      return 'CI';
+    case 'state_change':     return 'state change';
+    case 'team_mention':     return 'team mention';
+    case 'security_alert':   return 'security';
+    case 'approval_requested': return 'approval';
+    case 'member_feature_requested': return 'requested';
+    default:                 return reason;
+  }
+}
+
+export function NotificationRow({
+  notification: n,
+  matchedItem,
+  isWorkingSet,
+  selected,
+  onToggleSelected,
+  onMarkRead,
+  onJumpToItem,
+}: NotificationRowProps) {
+  const classes = [
+    'notification-row',
+    n.unread ? 'notification-unread' : 'notification-read',
+    isWorkingSet ? 'notification-working-set' : '',
+    selected ? 'notification-selected' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleOpen = () => {
+    window.open(notificationHtmlUrl(n), '_blank', 'noopener,noreferrer');
+  };
+
+  const handleJump = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (matchedItem && onJumpToItem) onJumpToItem(matchedItem);
+  };
+
+  const handleMarkRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onMarkRead(n.id);
+  };
+
+  return (
+    <div
+      className={classes}
+      onClick={handleOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') handleOpen();
+      }}
+    >
+      <input
+        type="checkbox"
+        className="notification-checkbox"
+        checked={selected}
+        onChange={() => onToggleSelected(n.id)}
+        onClick={(e) => e.stopPropagation()}
+        aria-label="Select notification"
+      />
+      <span
+        className="notification-icon"
+        title={n.subject.type}
+        aria-hidden
+      >
+        {subjectIcon(n.subject.type)}
+      </span>
+      <div className="notification-main">
+        <div className="notification-line">
+          {n.unread && <span className="notification-dot" aria-label="unread" />}
+          <span className="notification-title">{n.subject.title}</span>
+        </div>
+        <div className="notification-meta">
+          <span className="notification-repo">
+            {n.repo.owner}/{n.repo.name}
+          </span>
+          {n.subjectNumber != null && (
+            <span className="notification-number">#{n.subjectNumber}</span>
+          )}
+          <span className="notification-reason">{reasonLabel(n.reason)}</span>
+          {isWorkingSet && (
+            <span className="notification-badge-mine" title="On a PR you're working on">
+              yours
+            </span>
+          )}
+          <span className="notification-time">{timeAgo(n.updatedAt)}</span>
+        </div>
+      </div>
+      <div className="notification-actions">
+        {matchedItem && onJumpToItem && (
+          <button
+            className="notification-action"
+            onClick={handleJump}
+            title="Jump to row in the PR table"
+          >
+            ↪
+          </button>
+        )}
+        {n.unread && (
+          <button
+            className="notification-action"
+            onClick={handleMarkRead}
+            title="Mark as read"
+          >
+            ✓
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotificationsView.tsx
+++ b/src/components/NotificationsView.tsx
@@ -1,0 +1,291 @@
+import React, { useMemo, useState } from 'react';
+import type {
+  DashboardItem,
+  NotificationItem,
+  NotificationReason,
+} from '../../shared/types.js';
+import { matchNotifications } from '../../shared/utils/notificationMatch.js';
+import { NotificationRow } from './NotificationRow.js';
+
+interface NotificationsViewProps {
+  notifications: NotificationItem[];
+  loading: boolean;
+  error: string | null;
+  lastRefresh: Date | null;
+  /** All fetched PRs/issues — used to cross-reference and to derive working-set membership. */
+  items: DashboardItem[];
+  authUser: string | null;
+  onClose: () => void;
+  onRefresh: () => void;
+  onMarkRead: (id: string) => void;
+  onMarkManyRead: (ids: string[]) => Promise<unknown>;
+  onJumpToItem: ((item: DashboardItem) => void) | null;
+  /** If set, the view opens pre-filtered to notifications attached to this PR/issue. */
+  pinnedItem?: DashboardItem | null;
+}
+
+const REASON_FILTERS: ReadonlyArray<{ label: string; reason: NotificationReason | 'all' }> = [
+  { label: 'All', reason: 'all' },
+  { label: 'Mentions', reason: 'mention' },
+  { label: 'Review', reason: 'review_requested' },
+  { label: 'CI', reason: 'ci_activity' },
+  { label: 'Authored', reason: 'author' },
+  { label: 'Subscribed', reason: 'subscribed' },
+];
+
+export function NotificationsView({
+  notifications,
+  loading,
+  error,
+  lastRefresh,
+  items,
+  authUser,
+  onClose,
+  onRefresh,
+  onMarkRead,
+  onMarkManyRead,
+  onJumpToItem,
+  pinnedItem,
+}: NotificationsViewProps) {
+  const [search, setSearch] = useState('');
+  const [reasonFilter, setReasonFilter] = useState<NotificationReason | 'all'>('all');
+  const [unreadOnly, setUnreadOnly] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const matches = useMemo(
+    () => matchNotifications(notifications, items, authUser),
+    [notifications, items, authUser]
+  );
+
+  const filtered = useMemo(() => {
+    let result = matches;
+    if (pinnedItem) {
+      result = result.filter(
+        (m) =>
+          m.item != null &&
+          m.item.id === pinnedItem.id &&
+          m.item.kind === pinnedItem.kind
+      );
+    }
+    if (unreadOnly) {
+      result = result.filter((m) => m.notification.unread);
+    }
+    if (reasonFilter !== 'all') {
+      result = result.filter((m) => m.notification.reason === reasonFilter);
+    }
+    const q = search.trim().toLowerCase();
+    if (q) {
+      result = result.filter((m) => {
+        const n = m.notification;
+        return (
+          n.subject.title.toLowerCase().includes(q) ||
+          `${n.repo.owner}/${n.repo.name}`.toLowerCase().includes(q) ||
+          (n.subjectNumber != null && `#${n.subjectNumber}`.includes(q))
+        );
+      });
+    }
+    // Working-set rows float to the top, then unread, then by recency.
+    result = [...result].sort((a, b) => {
+      if (a.isWorkingSet !== b.isWorkingSet) return a.isWorkingSet ? -1 : 1;
+      if (a.notification.unread !== b.notification.unread) {
+        return a.notification.unread ? -1 : 1;
+      }
+      return (
+        new Date(b.notification.updatedAt).getTime() -
+        new Date(a.notification.updatedAt).getTime()
+      );
+    });
+    return result;
+  }, [matches, search, reasonFilter, unreadOnly, pinnedItem]);
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const selectAllVisible = () => {
+    const visibleIds = new Set(filtered.map((m) => m.notification.id));
+    if (
+      visibleIds.size > 0 &&
+      [...visibleIds].every((id) => selectedIds.has(id))
+    ) {
+      // All visible already selected → clear.
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of visibleIds) next.delete(id);
+        return next;
+      });
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of visibleIds) next.add(id);
+        return next;
+      });
+    }
+  };
+
+  const handleBulkMarkRead = async () => {
+    const ids = [...selectedIds];
+    clearSelection();
+    await onMarkManyRead(ids);
+  };
+
+  const unreadCount = matches.filter((m) => m.notification.unread).length;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="notifications-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Notifications"
+      >
+        <header className="notifications-header">
+          <div className="notifications-title-block">
+            <h2 className="notifications-title">Notifications</h2>
+            <span className="notifications-count">
+              {unreadCount} unread · {matches.length} total
+            </span>
+            {pinnedItem && (
+              <span
+                className="notifications-pinned-chip"
+                title="Filtered to this PR — clear by closing and reopening from the header"
+              >
+                {pinnedItem.repo.owner}/{pinnedItem.repo.name}#{pinnedItem.number}
+              </span>
+            )}
+          </div>
+          <div className="notifications-header-actions">
+            {lastRefresh && (
+              <span className="notifications-last-refresh" title="Last refreshed">
+                {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+            <button
+              className="notifications-icon-btn"
+              onClick={onRefresh}
+              disabled={loading}
+              title="Refresh"
+              aria-label="Refresh"
+            >
+              {loading ? <span className="spinner" /> : '↻'}
+            </button>
+            <button
+              className="notifications-icon-btn"
+              onClick={onClose}
+              title="Close (Esc)"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+        </header>
+
+        <div className="notifications-toolbar">
+          <input
+            type="text"
+            className="notifications-search"
+            placeholder="Search title, repo, #number…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <div className="notifications-reason-filters">
+            {REASON_FILTERS.map(({ label, reason }) => (
+              <button
+                key={reason}
+                className={
+                  'notifications-chip' +
+                  (reasonFilter === reason ? ' notifications-chip-active' : '')
+                }
+                onClick={() => setReasonFilter(reason)}
+                type="button"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <label className="notifications-toggle">
+            <input
+              type="checkbox"
+              checked={unreadOnly}
+              onChange={(e) => setUnreadOnly(e.target.checked)}
+            />
+            Unread only
+          </label>
+          <button
+            className="notifications-link-btn"
+            onClick={selectAllVisible}
+            type="button"
+            disabled={filtered.length === 0}
+          >
+            {filtered.every((m) => selectedIds.has(m.notification.id)) &&
+            filtered.length > 0
+              ? 'Clear selection'
+              : 'Select all visible'}
+          </button>
+        </div>
+
+        {error && (
+          <div className="notifications-error" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="notifications-list">
+          {filtered.length === 0 ? (
+            <div className="notifications-empty">
+              {loading
+                ? 'Loading…'
+                : unreadCount === 0
+                ? '🎉 Inbox zero — no unread notifications.'
+                : 'No notifications match the current filters.'}
+            </div>
+          ) : (
+            filtered.map((m) => (
+              <NotificationRow
+                key={m.notification.id}
+                notification={m.notification}
+                matchedItem={m.item}
+                isWorkingSet={m.isWorkingSet}
+                selected={selectedIds.has(m.notification.id)}
+                onToggleSelected={toggleSelected}
+                onMarkRead={onMarkRead}
+                onJumpToItem={onJumpToItem}
+              />
+            ))
+          )}
+        </div>
+
+        {selectedIds.size > 0 && (
+          <footer className="notifications-bulk-bar" role="region" aria-label="Bulk actions">
+            <span>
+              {selectedIds.size} selected
+            </span>
+            <div className="notifications-bulk-actions">
+              <button
+                className="notifications-link-btn"
+                onClick={clearSelection}
+                type="button"
+              >
+                Clear
+              </button>
+              <button
+                className="notifications-primary-btn"
+                onClick={handleBulkMarkRead}
+                type="button"
+              >
+                Mark {selectedIds.size} as read
+              </button>
+            </div>
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -4,6 +4,9 @@ import type { ViewMode, DashboardItem } from '../types.js';
 export function useModalState() {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [previewItem, setPreviewItem] = useState<DashboardItem | null>(null);
+  /** PR/issue the notifications view should be pre-filtered to (set via the PR table indicator). */
+  const [notificationsPinnedItem, setNotificationsPinnedItem] =
+    useState<DashboardItem | null>(null);
 
   const isModalOpen = viewMode !== 'list';
 
@@ -19,20 +22,29 @@ export function useModalState() {
 
   const openRepos = useCallback(() => setViewMode('repos'), []);
   const openHelp = useCallback(() => setViewMode('help'), []);
+  const openNotifications = useCallback((pinTo?: DashboardItem | null) => {
+    setNotificationsPinnedItem(pinTo ?? null);
+    setViewMode('notifications');
+  }, []);
+  const openRules = useCallback(() => setViewMode('notification-rules'), []);
   const closeModal = useCallback(() => {
     setViewMode('list');
     setPreviewItem(null);
+    setNotificationsPinnedItem(null);
   }, []);
 
   return {
     viewMode,
     setViewMode,
     previewItem,
+    notificationsPinnedItem,
     isModalOpen,
     openDetail,
     closeDetail,
     openRepos,
     openHelp,
+    openNotifications,
+    openRules,
     closeModal,
   };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import './styles/TokenSetup.css';
 import './styles/Onboarding.css';
 import './styles/StatusBar.css';
 import './styles/ErrorBoundary.css';
+import './styles/Notifications.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/styles/Notifications.css
+++ b/src/styles/Notifications.css
@@ -1,0 +1,365 @@
+/* ── Notifications view ─────────────────────────────────────── */
+
+.notifications-modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: min(900px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.notifications-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.notifications-title-block {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.notifications-title {
+  font-size: 18px;
+  margin: 0;
+}
+
+.notifications-count {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.notifications-pinned-chip {
+  font-size: 11px;
+  background: var(--bg-selected);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 1px 8px;
+  color: var(--text-muted);
+}
+
+.notifications-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.notifications-last-refresh {
+  font-size: 11px;
+  color: var(--text-subtle);
+}
+
+.notifications-icon-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.notifications-icon-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.notifications-icon-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Toolbar */
+
+.notifications-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.notifications-search {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.notifications-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.notifications-reason-filters {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.notifications-chip {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 3px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.notifications-chip:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.notifications-chip-active {
+  background: var(--bg-selected);
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.notifications-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.notifications-link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.notifications-link-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Error banner */
+
+.notifications-error {
+  background: rgba(248, 81, 73, 0.1);
+  border-bottom: 1px solid var(--red);
+  color: var(--red);
+  padding: 8px 18px;
+  font-size: 13px;
+}
+
+/* List */
+
+.notifications-list {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: 4px 0;
+}
+
+.notifications-empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* Row */
+
+.notification-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background-color 0.05s ease;
+}
+
+.notification-row:hover {
+  background: var(--bg-hover);
+}
+
+.notification-selected {
+  background: var(--bg-selected) !important;
+}
+
+.notification-read {
+  opacity: 0.6;
+}
+
+/* Working set: subtle left accent bar so it's immediately scannable. */
+.notification-working-set {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.notification-checkbox {
+  cursor: pointer;
+}
+
+.notification-icon {
+  width: 18px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.notification-main {
+  min-width: 0;
+}
+
+.notification-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.notification-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.notification-title {
+  font-size: 13px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notification-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+
+.notification-repo {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.notification-number {
+  color: var(--text-subtle);
+}
+
+.notification-reason {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 10px;
+  text-transform: lowercase;
+}
+
+.notification-badge-mine {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.notification-time {
+  margin-left: auto;
+  color: var(--text-subtle);
+}
+
+.notification-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.notification-action {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.notification-action:hover {
+  background: var(--bg);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+/* Bulk action bar */
+
+.notifications-bulk-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  position: sticky;
+  bottom: 0;
+}
+
+.notifications-bulk-actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.notifications-primary-btn {
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.notifications-primary-btn:hover {
+  opacity: 0.9;
+}
+
+/* Header badge for opening the notifications view */
+.notifications-trigger-badge {
+  background: var(--accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0 6px;
+  margin-left: 6px;
+  min-width: 16px;
+  text-align: center;
+}


### PR DESCRIPTION
Phase 2 of the notifications integration (#136). **Stacked on top of #137.** Review #137 first; this PR's diff only shows the Phase 2 additions.

## What's here

- **Header entry point.** New "Notifications" button with an unread-count badge next to the existing Repos button.
- **`NotificationsView` modal** (`src/components/NotificationsView.tsx`) — the dedicated triage surface:
  - Full-text search across title, repo, and `#number`.
  - Reason filter chips (All / Mentions / Review / CI / Authored / Subscribed).
  - "Unread only" toggle (default on).
  - Multi-select with "select all visible" affordance.
  - Sticky bulk-action bar: "Mark N as read".
  - Sorts working-set rows to the top, then unread, then by recency.
- **`NotificationRow`** (`src/components/NotificationRow.tsx`) — per-row UI:
  - Subject-type icon, title, repo, `#number`, reason badge, time ago.
  - **Working-set highlight** — rows tied to PRs the user authored, was requested to review, or is assigned to get a left accent rail + a "yours" badge.
  - Row click opens the thread on github.com. Per-row actions: mark read (✓) and jump-to-PR (↪) when the notification matches a row in the main table.
- **`shared/utils/notificationHtmlUrl`** — translates the API URL each notification carries (e.g. `.../repos/foo/bar/pulls/42`) into the equivalent github.com HTML URL so the click-through Just Works for PRs, issues, commits, and releases. Tested.
- **`useModalState` extension** — tracks a `notificationsPinnedItem` so future entry points (the PR-table indicator coming in Phase 3) can pre-filter the view to a single PR.
- **401 unification** — a 401 on notifications polling reuses the same re-auth flow as the main PR fetch.

## What's not here yet

- Rules engine UI (Phase 4).
- Rules auto-apply on refresh (Phase 5).
- PR-table notification indicator (Phase 3).
- Mobile parity (Phase 6).
- Settings UI for refresh interval / enabled toggle (Phase 7).

## Verification

- `npm test` — **320 passing** (was 315; +5 for `notificationHtmlUrl`).
- `npm run build` — clean TypeScript build, 394 modules.
- Manual verification needed in the browser: sign in with a token that has the `notifications` scope, click the Notifications button, exercise search/filter/multi-select/mark-read.

## Closes / refs

Refs #136. Stacked on #137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications interface accessible from the header with unread count badge
  * Notifications modal supports searching, filtering by reason, and pinning items
  * Bulk selection and mark-as-read actions for managing multiple notifications
  * Integrated with existing dashboard items for quick navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/landingit/pull/138)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->