### PR TITLE
Phase 3: PR table unread-notification indicator

### DIFF
--- a/shared/columns.ts
+++ b/shared/columns.ts
@@ -14,6 +14,7 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
   { id: 'repo', label: 'Repo', className: 'col-repo', sortKey: 'repo', defaultVisible: true },
   { id: 'number', label: '#', className: 'col-number', sortKey: 'number', defaultVisible: true },
   { id: 'state', label: 'State', className: 'col-state', sortKey: 'state', defaultVisible: true },
+  { id: 'notifications', label: '🔔', className: 'col-notifications', defaultVisible: true },
   { id: 'title', label: 'Title', className: 'col-title', sortKey: 'title', defaultVisible: true },
   { id: 'author', label: 'Author', className: 'col-author', sortKey: 'author', defaultVisible: true },
   { id: 'assignees', label: 'Assignees', className: 'col-assignees', sortKey: 'assignees', defaultVisible: true },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import { useFilteredItems } from './hooks/useFilteredItems.js';
 import { useModalState } from './hooks/useModalState.js';
 import { useColumnSettings } from './hooks/useColumnSettings.js';
 import { useNotifications } from '../shared/hooks/useNotifications.js';
+import { notificationsByItemKey, itemKey } from '../shared/utils/notificationMatch.js';
 import { webStorage } from './storage/webStorage.js';
 import { Header } from './components/Header.js';
 import { FilterBar } from './components/FilterBar.js';
@@ -157,6 +158,19 @@ export function App() {
   const notificationsUnreadCount = useMemo(
     () => notifications.filter((n) => n.unread).length,
     [notifications]
+  );
+
+  /** Map keyed by `${owner}/${repo}#${number}` → unread thread count, for the PR-table indicator. */
+  const unreadNotificationsByItem = useMemo(() => {
+    const grouped = notificationsByItemKey(notifications.filter((n) => n.unread));
+    const counts = new Map<string, number>();
+    for (const [key, list] of grouped) counts.set(key, list.length);
+    return counts;
+  }, [notifications]);
+
+  const getUnreadNotificationCount = useCallback(
+    (item: DashboardItem) => unreadNotificationsByItem.get(itemKey(item)) ?? 0,
+    [unreadNotificationsByItem]
   );
 
   // Treat a 401 from notifications the same as a 401 from the main fetch.
@@ -335,7 +349,9 @@ export function App() {
         onSort={handleSetSort}
         onPreview={previewPR}
         isUnseen={isUnseen}
+        getUnreadNotificationCount={getUnreadNotificationCount}
         onOpen={markSeen}
+        onOpenNotifications={openNotifications}
         onHideRepo={toggleRepoByName}
         staleDays={config.defaults.staleDays}
         visibleColumns={visibleColumns}

--- a/src/components/PRRow.tsx
+++ b/src/components/PRRow.tsx
@@ -11,13 +11,16 @@ export interface PRRowProps {
   selected: boolean;
   unseen: boolean;
   stale: boolean;
+  /** Count of unread notifications attached to this PR/issue. */
+  unreadNotificationCount?: number;
   onPreview: (item: DashboardItem) => void;
   onOpen: (item: DashboardItem) => void;
+  onOpenNotifications?: (item: DashboardItem) => void;
   onHideRepo?: (owner: string, name: string) => void;
   visibleColumns: string[];
 }
 
-export function PRRow({ item, selected, unseen, stale, onPreview, onOpen, onHideRepo, visibleColumns }: PRRowProps) {
+export function PRRow({ item, selected, unseen, stale, unreadNotificationCount = 0, onPreview, onOpen, onOpenNotifications, onHideRepo, visibleColumns }: PRRowProps) {
 
   const handleClick = () => {
     onOpen(item);
@@ -77,6 +80,27 @@ export function PRRow({ item, selected, unseen, stale, onPreview, onOpen, onHide
             {item.state}
           </span>
         )}
+      </td>
+    ),
+    notifications: () => (
+      <td key="notifications" className="col-notifications">
+        {unreadNotificationCount > 0 ? (
+          <button
+            type="button"
+            className="row-notification-indicator"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenNotifications?.(item);
+            }}
+            title={`${unreadNotificationCount} unread notification${unreadNotificationCount === 1 ? '' : 's'} on this item — click to view`}
+            aria-label={`Open ${unreadNotificationCount} notifications`}
+          >
+            <span className="row-notification-dot" />
+            {unreadNotificationCount > 1 && (
+              <span className="row-notification-count">{unreadNotificationCount}</span>
+            )}
+          </button>
+        ) : null}
       </td>
     ),
     title: () => (

--- a/src/components/PRTable.tsx
+++ b/src/components/PRTable.tsx
@@ -23,7 +23,10 @@ interface PRTableProps {
   onSort: (key: SortMode) => void;
   onPreview: (item: DashboardItem) => void;
   isUnseen: (item: DashboardItem) => boolean;
+  /** Returns the count of unread notifications attached to the given item. */
+  getUnreadNotificationCount: (item: DashboardItem) => number;
   onOpen: (item: DashboardItem) => void;
+  onOpenNotifications?: (item: DashboardItem) => void;
   onHideRepo?: (owner: string, name: string) => void;
   staleDays: number;
   visibleColumns: string[];
@@ -34,7 +37,7 @@ interface PRTableProps {
   milestoneGrouping?: boolean;
 }
 
-export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPreview, isUnseen, onOpen, onHideRepo, staleDays, visibleColumns, columnOrder, onToggleColumn, onReorderColumns, onResetColumns, milestoneGrouping }: PRTableProps) {
+export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPreview, isUnseen, getUnreadNotificationCount, onOpen, onOpenNotifications, onHideRepo, staleDays, visibleColumns, columnOrder, onToggleColumn, onReorderColumns, onResetColumns, milestoneGrouping }: PRTableProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const prevCursorIndexRef = useRef<number | null>(null);
   const { isCollapsed, toggle } = useMilestoneCollapse();
@@ -187,8 +190,10 @@ export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPre
                   selected={entry.flatIndex === cursorIndex}
                   unseen={isUnseen(entry.item)}
                   stale={isStale(entry.item, staleDays)}
+                  unreadNotificationCount={getUnreadNotificationCount(entry.item)}
                   onPreview={onPreview}
                   onOpen={onOpen}
+                  onOpenNotifications={onOpenNotifications}
                   onHideRepo={onHideRepo}
                   visibleColumns={orderedVisibleColumns.map((c) => c.id)}
                 />
@@ -203,8 +208,10 @@ export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPre
                 selected={virtualRow.index === cursorIndex}
                 unseen={isUnseen(item)}
                 stale={isStale(item, staleDays)}
+                unreadNotificationCount={getUnreadNotificationCount(item)}
                 onPreview={onPreview}
                 onOpen={onOpen}
+                onOpenNotifications={onOpenNotifications}
                 onHideRepo={onHideRepo}
                 visibleColumns={orderedVisibleColumns.map((c) => c.id)}
               />

--- a/src/styles/Notifications.css
+++ b/src/styles/Notifications.css
@@ -363,3 +363,39 @@
   min-width: 16px;
   text-align: center;
 }
+
+/* PR-table notification indicator cell */
+.col-notifications {
+  width: 36px;
+  text-align: center;
+}
+
+.row-notification-indicator {
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.row-notification-indicator:hover .row-notification-dot {
+  transform: scale(1.2);
+}
+
+.row-notification-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  transition: transform 0.1s ease;
+}
+
+.row-notification-count {
+  font-size: 10px;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Phase 3 of the notifications integration (#136). **Stacked on top of #138** (which is stacked on #137). Review #137 → #138 → this in order; the diff here only shows Phase 3.

## What's here

A small but high-value cross-link from the notifications data back into the main PR table:

- New 🔔 column (between State and Title) rendering a dot on rows whose PR/issue has unread notifications.
- When more than one unread notification is attached to a single PR, the count is rendered next to the dot.
- Clicking the indicator opens the `NotificationsView` pre-filtered to that PR via `notificationsPinnedItem` (already wired in #138).
- Hover shows a tooltip: "N unread notifications on this item — click to view".

## Implementation notes

- The mapping is computed once per refresh in `app.tsx` from `shared/utils/notificationMatch.ts:notificationsByItemKey` and exposed to `PRTable` as a `getUnreadNotificationCount(item) => number` callback — same pattern as `isUnseen`.
- `PRRow.unreadNotificationCount` is optional with a default of `0` so the existing 27 `PRRow` test cases continue to pass without churn.
- The new column is in `DEFAULT_COLUMNS` with `defaultVisible: true`. Users can toggle it off via the existing column-settings dropdown.

## Verification

- `npm test` — **320 passing**, unchanged from #138.
- `npm run build` — clean.
- Manual: with the notifications view open in another tab to confirm the underlying data, the table should show a dot on rows whose corresponding PR has unread mentions/reviews/etc.

## Closes / refs

Refs #136. Stacked on #138 → #137.