### PR TITLE
Phases 4 + 5: notification rules editor with quick-apply chips and auto-apply on refresh

### DIFF
--- a/shared/hooks/useNotifications.ts
+++ b/shared/hooks/useNotifications.ts
@@ -18,6 +18,12 @@ interface UseNotificationsOptions {
   /** Auto-refresh interval in seconds. 0 disables polling. */
   refreshIntervalSeconds: number;
   storage: StorageAdapter;
+  /**
+   * Called after each successful refresh with the freshly-fetched notifications.
+   * Used by app.tsx to wire up rules `autoApply` — the hook stays unaware of
+   * the rules engine, callers compose the two.
+   */
+  onAfterRefresh?: (notifications: NotificationItem[]) => void;
 }
 
 interface UseNotificationsResult {
@@ -50,6 +56,7 @@ export function useNotifications({
   enabled,
   refreshIntervalSeconds,
   storage,
+  onAfterRefresh,
 }: UseNotificationsOptions): UseNotificationsResult {
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -64,6 +71,8 @@ export function useNotifications({
   storageRef.current = storage;
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
+  const onAfterRefreshRef = useRef(onAfterRefresh);
+  onAfterRefreshRef.current = onAfterRefresh;
 
   const refresh = useCallback(() => {
     setRefreshCounter((c) => c + 1);
@@ -107,6 +116,9 @@ export function useNotifications({
               .setItem(STORAGE_KEYS.NOTIFICATIONS_LAST_MODIFIED, result.lastModified)
               .catch(() => {});
           }
+          // Notify the caller so auto-apply rules can run against fresh data.
+          // Guarded so 304 ticks don't re-trigger rules against unchanged data.
+          onAfterRefreshRef.current?.(result.notifications);
         }
 
         setLastRefresh(new Date());

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import type { DashboardItem, OwnershipFilter } from './types.js';
+import type { DashboardItem, NotificationItem, OwnershipFilter } from './types.js';
 import { createClient, type RateLimit } from './github/client.js';
 import { isAuthError } from './github/errors.js';
 import { getToken, setToken as saveToken, clearToken } from './config.js';
@@ -14,6 +14,10 @@ import { useFilteredItems } from './hooks/useFilteredItems.js';
 import { useModalState } from './hooks/useModalState.js';
 import { useColumnSettings } from './hooks/useColumnSettings.js';
 import { useNotifications } from '../shared/hooks/useNotifications.js';
+import {
+  useNotificationRules,
+  notificationsMatchingRule,
+} from '../shared/hooks/useNotificationRules.js';
 import { notificationsByItemKey, itemKey } from '../shared/utils/notificationMatch.js';
 import { webStorage } from './storage/webStorage.js';
 import { Header } from './components/Header.js';
@@ -26,6 +30,7 @@ import { TokenSetup } from './components/TokenSetup.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { DetailPanel } from './components/DetailPanel.js';
 import { NotificationsView } from './components/NotificationsView.js';
+import { NotificationRulesEditor } from './components/NotificationRulesEditor.js';
 
 const OWNERSHIP_CYCLE: OwnershipFilter[] = ['created', 'assigned', 'involved', 'everyone'];
 
@@ -46,7 +51,7 @@ export function App() {
 
   const {
     viewMode, setViewMode, previewItem, notificationsPinnedItem, isModalOpen,
-    openDetail, closeDetail, openRepos, openNotifications, closeModal,
+    openDetail, closeDetail, openRepos, openNotifications, openRules, closeModal,
   } = useModalState();
 
   const handleRateLimit = useCallback((rl: RateLimit) => setRateLimit(rl), []);
@@ -139,6 +144,34 @@ export function App() {
     onRefresh: refresh,
   });
 
+  // `rulesRef` lets the refresh-time auto-apply callback read the latest
+  // rules without re-instantiating the notifications hook on every rule
+  // edit (which would re-trigger a fetch).
+  const rulesRef = useRef<ReturnType<typeof useNotificationRules>['rules']>([]);
+
+  const handleAfterNotificationsRefresh = useCallback(
+    (fresh: NotificationItem[] | undefined) => {
+      if (!fresh) return;
+      const ids = new Set<string>();
+      for (const rule of rulesRef.current) {
+        if (!rule.enabled || !rule.autoApply) continue;
+        for (const n of notificationsMatchingRule(rule, fresh)) {
+          if (n.unread) ids.add(n.id);
+        }
+      }
+      if (ids.size > 0) {
+        // Fire-and-forget; failures are surfaced through the optimistic
+        // rollback in useNotifications.
+        void markThreadsReadRef.current?.([...ids]);
+      }
+    },
+    []
+  );
+
+  // We need to reference markThreadsRead inside the callback above, but the
+  // hook hasn't returned yet. Forward via a ref.
+  const markThreadsReadRef = useRef<((ids: string[]) => Promise<unknown>) | null>(null);
+
   const {
     notifications,
     loading: notificationsLoading,
@@ -153,7 +186,12 @@ export function App() {
     enabled: config.defaults.notificationsEnabled,
     refreshIntervalSeconds: config.defaults.notificationsRefreshInterval,
     storage: webStorage,
+    onAfterRefresh: handleAfterNotificationsRefresh,
   });
+
+  // Keep the ref in sync so the after-refresh callback always sees the
+  // freshest mark-read function.
+  markThreadsReadRef.current = markThreadsRead;
 
   const notificationsUnreadCount = useMemo(
     () => notifications.filter((n) => n.unread).length,
@@ -171,6 +209,27 @@ export function App() {
   const getUnreadNotificationCount = useCallback(
     (item: DashboardItem) => unreadNotificationsByItem.get(itemKey(item)) ?? 0,
     [unreadNotificationsByItem]
+  );
+
+  const {
+    rules,
+    addRule,
+    updateRule,
+    deleteRule,
+    toggleRule,
+  } = useNotificationRules({ storage: webStorage });
+
+  // Keep rulesRef in sync for the after-refresh auto-apply callback.
+  rulesRef.current = rules;
+
+  const applyRule = useCallback(
+    async (rule: typeof rules[number]) => {
+      const matches = notificationsMatchingRule(rule, notifications);
+      const ids = matches.filter((n) => n.unread).map((n) => n.id);
+      if (ids.length === 0) return;
+      await markThreadsRead(ids);
+    },
+    [notifications, markThreadsRead]
   );
 
   // Treat a 401 from notifications the same as a 401 from the main fetch.
@@ -390,12 +449,27 @@ export function App() {
           lastRefresh={notificationsLastRefresh}
           items={items}
           authUser={username}
+          rules={rules}
+          onApplyRule={applyRule}
+          onOpenRules={openRules}
           onClose={closeModal}
           onRefresh={refreshNotifications}
           onMarkRead={markThreadRead}
           onMarkManyRead={markThreadsRead}
           onJumpToItem={jumpToItem}
           pinnedItem={notificationsPinnedItem}
+        />
+      )}
+      {viewMode === 'notification-rules' && (
+        <NotificationRulesEditor
+          rules={rules}
+          notifications={notifications}
+          onClose={closeModal}
+          onAdd={addRule}
+          onUpdate={updateRule}
+          onDelete={deleteRule}
+          onToggle={toggleRule}
+          onApplyRule={applyRule}
         />
       )}
     </div>

--- a/src/components/NotificationRulesEditor.tsx
+++ b/src/components/NotificationRulesEditor.tsx
@@ -1,0 +1,366 @@
+import React, { useMemo, useState } from 'react';
+import type {
+  NotificationItem,
+  NotificationRule,
+  RuleCondition,
+  RuleField,
+  RuleOp,
+} from '../../shared/types.js';
+import {
+  BUILTIN_PRESETS,
+  notificationsMatchingRule,
+} from '../../shared/hooks/useNotificationRules.js';
+
+interface NotificationRulesEditorProps {
+  rules: NotificationRule[];
+  notifications: NotificationItem[];
+  onClose: () => void;
+  onAdd: (input: Omit<NotificationRule, 'id' | 'createdAt'>) => NotificationRule;
+  onUpdate: (
+    id: string,
+    patch: Partial<Omit<NotificationRule, 'id' | 'createdAt'>>
+  ) => void;
+  onDelete: (id: string) => void;
+  onToggle: (id: string) => void;
+  onApplyRule: (rule: NotificationRule) => Promise<unknown>;
+}
+
+const FIELD_OPTIONS: ReadonlyArray<{ value: RuleField; label: string }> = [
+  { value: 'title', label: 'Title' },
+  { value: 'author', label: 'Author (login)' },
+  { value: 'repo', label: 'Repo (owner/name)' },
+  { value: 'reason', label: 'Reason' },
+  { value: 'subjectType', label: 'Subject type' },
+];
+
+const OP_OPTIONS: ReadonlyArray<{ value: RuleOp; label: string }> = [
+  { value: 'startsWith', label: 'starts with' },
+  { value: 'equals', label: 'equals' },
+  { value: 'contains', label: 'contains' },
+  { value: 'regex', label: 'matches regex' },
+];
+
+function emptyRule(): Omit<NotificationRule, 'id' | 'createdAt'> {
+  return {
+    name: '',
+    enabled: true,
+    autoApply: false,
+    conditions: [{ field: 'title', op: 'startsWith', value: '' }],
+    action: 'mark-read',
+  };
+}
+
+export function NotificationRulesEditor({
+  rules,
+  notifications,
+  onClose,
+  onAdd,
+  onUpdate,
+  onDelete,
+  onToggle,
+  onApplyRule,
+}: NotificationRulesEditorProps) {
+  const [draft, setDraft] = useState<Omit<NotificationRule, 'id' | 'createdAt'> | null>(
+    null
+  );
+
+  const draftMatchCount = useMemo(() => {
+    if (!draft) return 0;
+    return notificationsMatchingRule(
+      { ...draft, id: '__draft__', createdAt: new Date().toISOString() },
+      notifications
+    ).length;
+  }, [draft, notifications]);
+
+  const handleAddPreset = (presetName: string) => {
+    const preset = BUILTIN_PRESETS.find((p) => p.name === presetName);
+    if (!preset) return;
+    onAdd({ ...preset });
+  };
+
+  const startNew = () => setDraft(emptyRule());
+  const cancelDraft = () => setDraft(null);
+
+  const saveDraft = () => {
+    if (!draft) return;
+    if (!draft.name.trim() || draft.conditions.length === 0) return;
+    onAdd(draft);
+    setDraft(null);
+  };
+
+  const updateDraftCondition = (
+    idx: number,
+    patch: Partial<RuleCondition>
+  ) => {
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const next = [...prev.conditions];
+      next[idx] = { ...next[idx], ...patch };
+      return { ...prev, conditions: next };
+    });
+  };
+
+  const addDraftCondition = () => {
+    setDraft((prev) =>
+      prev
+        ? {
+            ...prev,
+            conditions: [
+              ...prev.conditions,
+              { field: 'title', op: 'startsWith', value: '' },
+            ],
+          }
+        : prev
+    );
+  };
+
+  const removeDraftCondition = (idx: number) => {
+    setDraft((prev) =>
+      prev
+        ? { ...prev, conditions: prev.conditions.filter((_, i) => i !== idx) }
+        : prev
+    );
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="notifications-modal rules-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Notification rules"
+      >
+        <header className="notifications-header">
+          <div className="notifications-title-block">
+            <h2 className="notifications-title">Notification Rules</h2>
+            <span className="notifications-count">
+              {rules.length} rule{rules.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          <div className="notifications-header-actions">
+            <button
+              className="notifications-icon-btn"
+              onClick={onClose}
+              title="Close (Esc)"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+        </header>
+
+        <div className="rules-presets">
+          <span className="rules-presets-label">Add preset:</span>
+          {BUILTIN_PRESETS.map((preset) => (
+            <button
+              key={preset.name}
+              type="button"
+              className="notifications-chip"
+              onClick={() => handleAddPreset(preset.name)}
+              title={preset.conditions
+                .map((c) => `${c.field} ${c.op} "${c.value}"`)
+                .join(' AND ')}
+            >
+              + {preset.name}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="notifications-link-btn"
+            onClick={startNew}
+            disabled={draft !== null}
+          >
+            + Custom rule
+          </button>
+        </div>
+
+        <div className="rules-list">
+          {rules.length === 0 && !draft && (
+            <div className="notifications-empty">
+              No rules yet. Add a preset above, or click "Custom rule" to build
+              one from scratch.
+            </div>
+          )}
+
+          {rules.map((rule) => {
+            const matchCount = notificationsMatchingRule(rule, notifications).length;
+            return (
+              <div key={rule.id} className="rule-row">
+                <div className="rule-main">
+                  <div className="rule-name-line">
+                    <label className="rules-toggle">
+                      <input
+                        type="checkbox"
+                        checked={rule.enabled}
+                        onChange={() => onToggle(rule.id)}
+                      />
+                      <strong className={rule.enabled ? '' : 'text-muted'}>
+                        {rule.name}
+                      </strong>
+                    </label>
+                    <span className="rule-match-count">
+                      {matchCount} matching
+                    </span>
+                  </div>
+                  <div className="rule-conditions-summary">
+                    {rule.conditions.map((c, i) => (
+                      <span key={i} className="rule-condition-pill">
+                        <span className="rule-cond-field">{c.field}</span>
+                        <span className="rule-cond-op">{c.op}</span>
+                        <span className="rule-cond-value">"{c.value}"</span>
+                        {i < rule.conditions.length - 1 && (
+                          <span className="rule-cond-and"> AND </span>
+                        )}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="rule-actions">
+                  <label className="rules-toggle" title="Auto-apply on each refresh">
+                    <input
+                      type="checkbox"
+                      checked={rule.autoApply}
+                      onChange={(e) =>
+                        onUpdate(rule.id, { autoApply: e.target.checked })
+                      }
+                    />
+                    auto
+                  </label>
+                  <button
+                    type="button"
+                    className="notifications-link-btn"
+                    onClick={() => onApplyRule(rule)}
+                    disabled={matchCount === 0 || !rule.enabled}
+                    title="Mark all matching notifications as read now"
+                  >
+                    Apply now
+                  </button>
+                  <button
+                    type="button"
+                    className="notification-action"
+                    onClick={() => onDelete(rule.id)}
+                    title="Delete rule"
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+
+          {draft && (
+            <div className="rule-row rule-draft">
+              <div className="rule-main">
+                <input
+                  type="text"
+                  className="notifications-search"
+                  placeholder='Rule name (e.g. "Bump PRs in non-core repos")'
+                  value={draft.name}
+                  onChange={(e) =>
+                    setDraft((prev) => prev && { ...prev, name: e.target.value })
+                  }
+                  autoFocus
+                />
+                <div className="rule-conditions-editor">
+                  {draft.conditions.map((cond, idx) => (
+                    <div key={idx} className="rule-condition-edit">
+                      <select
+                        className="rule-select"
+                        value={cond.field}
+                        onChange={(e) =>
+                          updateDraftCondition(idx, {
+                            field: e.target.value as RuleField,
+                          })
+                        }
+                      >
+                        {FIELD_OPTIONS.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        className="rule-select"
+                        value={cond.op}
+                        onChange={(e) =>
+                          updateDraftCondition(idx, {
+                            op: e.target.value as RuleOp,
+                          })
+                        }
+                      >
+                        {OP_OPTIONS.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        type="text"
+                        className="rule-value-input"
+                        placeholder="value"
+                        value={cond.value}
+                        onChange={(e) =>
+                          updateDraftCondition(idx, { value: e.target.value })
+                        }
+                      />
+                      {draft.conditions.length > 1 && (
+                        <button
+                          type="button"
+                          className="notification-action"
+                          onClick={() => removeDraftCondition(idx)}
+                          title="Remove condition"
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    className="notifications-link-btn"
+                    onClick={addDraftCondition}
+                  >
+                    + Add condition (AND)
+                  </button>
+                </div>
+                <span className="rule-match-count">
+                  Would match {draftMatchCount} current notification
+                  {draftMatchCount === 1 ? '' : 's'}
+                </span>
+              </div>
+              <div className="rule-actions">
+                <label className="rules-toggle">
+                  <input
+                    type="checkbox"
+                    checked={draft.autoApply}
+                    onChange={(e) =>
+                      setDraft(
+                        (prev) => prev && { ...prev, autoApply: e.target.checked }
+                      )
+                    }
+                  />
+                  auto-apply
+                </label>
+                <button
+                  type="button"
+                  className="notifications-link-btn"
+                  onClick={cancelDraft}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="notifications-primary-btn"
+                  onClick={saveDraft}
+                  disabled={!draft.name.trim() || draft.conditions.length === 0}
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotificationsView.tsx
+++ b/src/components/NotificationsView.tsx
@@ -3,8 +3,10 @@ import type {
   DashboardItem,
   NotificationItem,
   NotificationReason,
+  NotificationRule,
 } from '../../shared/types.js';
 import { matchNotifications } from '../../shared/utils/notificationMatch.js';
+import { notificationsMatchingRule } from '../../shared/hooks/useNotificationRules.js';
 import { NotificationRow } from './NotificationRow.js';
 
 interface NotificationsViewProps {
@@ -15,6 +17,9 @@ interface NotificationsViewProps {
   /** All fetched PRs/issues — used to cross-reference and to derive working-set membership. */
   items: DashboardItem[];
   authUser: string | null;
+  rules: NotificationRule[];
+  onApplyRule: (rule: NotificationRule) => Promise<unknown>;
+  onOpenRules: () => void;
   onClose: () => void;
   onRefresh: () => void;
   onMarkRead: (id: string) => void;
@@ -40,6 +45,9 @@ export function NotificationsView({
   lastRefresh,
   items,
   authUser,
+  rules,
+  onApplyRule,
+  onOpenRules,
   onClose,
   onRefresh,
   onMarkRead,
@@ -230,6 +238,53 @@ export function NotificationsView({
               : 'Select all visible'}
           </button>
         </div>
+
+        {rules.length > 0 && (
+          <div className="notifications-rules-bar">
+            <span className="rules-presets-label">Rules:</span>
+            {rules
+              .filter((r) => r.enabled)
+              .map((rule) => {
+                const matchCount = notificationsMatchingRule(rule, notifications).length;
+                return (
+                  <button
+                    key={rule.id}
+                    type="button"
+                    className="notifications-chip"
+                    onClick={() => onApplyRule(rule)}
+                    disabled={matchCount === 0}
+                    title={rule.conditions
+                      .map((c) => `${c.field} ${c.op} "${c.value}"`)
+                      .join(' AND ')}
+                  >
+                    {rule.name}{' '}
+                    <span className="rule-chip-count">({matchCount})</span>
+                  </button>
+                );
+              })}
+            <button
+              type="button"
+              className="notifications-link-btn"
+              onClick={onOpenRules}
+            >
+              Edit rules
+            </button>
+          </div>
+        )}
+        {rules.length === 0 && (
+          <div className="notifications-rules-bar">
+            <span className="rules-presets-label notifications-muted">
+              No rules yet —
+            </span>
+            <button
+              type="button"
+              className="notifications-link-btn"
+              onClick={onOpenRules}
+            >
+              Add a rule to bulk-mark common noise
+            </button>
+          </div>
+        )}
 
         {error && (
           <div className="notifications-error" role="alert">

--- a/src/styles/Notifications.css
+++ b/src/styles/Notifications.css
@@ -364,6 +364,174 @@
   text-align: center;
 }
 
+/* Rules quick-action bar inside NotificationsView */
+.notifications-rules-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.notifications-rules-bar .notifications-chip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.notifications-muted {
+  color: var(--text-subtle);
+}
+
+.rule-chip-count {
+  font-size: 10px;
+  color: var(--text-subtle);
+}
+
+/* Rules editor modal */
+.rules-modal {
+  max-width: 760px;
+}
+
+.rules-presets {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.rules-presets-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.rules-list {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: 8px 0;
+}
+
+.rule-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.rule-row.rule-draft {
+  background: var(--bg-selected);
+}
+
+.rule-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rule-name-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rules-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.rule-match-count {
+  font-size: 11px;
+  color: var(--text-subtle);
+  margin-left: auto;
+}
+
+.rule-conditions-summary {
+  font-size: 12px;
+  color: var(--text-muted);
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.rule-condition-pill {
+  display: inline-flex;
+  gap: 4px;
+  align-items: baseline;
+}
+
+.rule-cond-field {
+  color: var(--accent);
+}
+
+.rule-cond-op {
+  color: var(--text-subtle);
+}
+
+.rule-cond-value {
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.rule-cond-and {
+  color: var(--text-subtle);
+  font-weight: 600;
+}
+
+.rule-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rule-conditions-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rule-condition-edit {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.rule-select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.rule-value-input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.rule-value-input:focus,
+.rule-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 /* PR-table notification indicator cell */
 .col-notifications {
   width: 36px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,4 +24,11 @@ export type {
   TimelineEventType,
   TimelineEvent,
   PRDetail,
+  NotificationItem,
+  NotificationRule,
+  NotificationReason,
+  NotificationSubjectType,
+  RuleCondition,
+  RuleField,
+  RuleOp,
 } from '../shared/types.js';


### PR DESCRIPTION
Phases 4 and 5 of the notifications integration (#136). **Stacked on #139** (→ #138 → #137). Review the stack in order; the diff here only shows the rules-engine UI and auto-apply wiring.

This is where the issue's headline feature lands: **one click to mark every "Bump …" notification read**, plus auto-apply so it happens silently on every refresh once the rule is enabled.

## What's here

### Phase 4 — rules editor + presets

- **`NotificationRulesEditor`** (`src/components/NotificationRulesEditor.tsx`) — modal for CRUD over user-defined rules:
  - "+ Dependabot bumps / Bot threads / CI activity" preset buttons that materialize `BUILTIN_PRESETS` as saved, user-owned rules (edit/delete like any other rule).
  - "+ Custom rule" inline editor: name, conditions (field + op + value, AND-combined), live "Would match N current notifications" counter that updates as the user types.
  - Per-rule controls: enabled toggle, auto-apply toggle, "Apply now" button (disabled when no matches), delete.

- **Quick-action chips in `NotificationsView`.** Each enabled rule shows up as a chip in a bar above the list with its current unread match count. One click marks every matching unread thread as read. Empty state prompts the user to add a first rule. An "Edit rules" link opens the editor.

### Phase 5 — auto-apply on refresh

- `useNotifications` grew an `onAfterRefresh` callback so `app.tsx` can run every rule with `autoApply: true` against fresh notifications after each successful poll, marking matches read without user interaction.
- The 304 path is skipped — auto-apply only fires when there's *new* data, so we don't re-run rules against an unchanged inbox (and don't churn the API for no reason).
- The callback is wired through refs so rule edits don't re-instantiate the notifications hook (which would re-trigger a fetch on every keystroke in the editor).

## Verification

- `npm test` — **320 passing** (no new tests; the rule evaluator was already tested in #137 with 13 cases).
- `npm run build` — clean TypeScript build, 396 modules.
- Manual:
  1. Open the rules editor, click "+ Dependabot bumps". A rule is saved.
  2. Close the editor — the chip appears in the notifications view with the current Bump count.
  3. Click the chip — every Bump notification gets marked read on github.com.
  4. Toggle the rule's "auto" checkbox. Wait 60s for the next poll — any new Bump notifications are silently marked read.

## What's not here yet

- Mobile parity (Phase 6).
- Settings UI for refresh interval / enabled toggle (Phase 7).

## Closes / refs

Refs #136. Stacked on #139 → #138 → #137.