### PR TITLE
Phase 6: mobile notifications tab with badge and rules editor

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -6,14 +6,25 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { AppProvider, useApp } from './src/context/AppContext';
 import { ConfigProvider, useConfigContext } from './src/context/ConfigContext';
 import { BadgeProvider, useBadge } from './src/context/BadgeContext';
+import {
+  NotificationsProvider,
+  useNotificationsContext,
+} from './src/context/NotificationsContext';
 import { TokenSetupScreen } from './src/screens/TokenSetupScreen';
 import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { PRListScreen } from './src/screens/PRListScreen';
 import { PRDetailScreen } from './src/screens/PRDetailScreen';
 import { SettingsScreen } from './src/screens/SettingsScreen';
-import type { DashboardStackParamList, RootTabParamList } from './src/navigation/types';
+import { NotificationsScreen } from './src/screens/NotificationsScreen';
+import { NotificationRulesScreen } from './src/screens/NotificationRulesScreen';
+import type {
+  DashboardStackParamList,
+  NotificationsStackParamList,
+  RootTabParamList,
+} from './src/navigation/types';
 
 const DashboardStack = createNativeStackNavigator<DashboardStackParamList>();
+const NotificationsStack = createNativeStackNavigator<NotificationsStackParamList>();
 const Tab = createBottomTabNavigator<RootTabParamList>();
 
 const navTheme = {
@@ -51,10 +62,34 @@ function DashboardNavigator() {
   );
 }
 
+function NotificationsNavigator() {
+  return (
+    <NotificationsStack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: '#161b22' },
+        headerTintColor: '#e6edf3',
+        headerTitleStyle: { fontSize: 16 },
+      }}
+    >
+      <NotificationsStack.Screen
+        name="Notifications"
+        component={NotificationsScreen}
+        options={{ title: 'Notifications' }}
+      />
+      <NotificationsStack.Screen
+        name="NotificationRules"
+        component={NotificationRulesScreen}
+        options={{ title: 'Notification Rules' }}
+      />
+    </NotificationsStack.Navigator>
+  );
+}
+
 function MainApp() {
   const { token, username, loading, saveToken, signOut } = useApp();
   const { config, configLoaded, addRepo } = useConfigContext();
   const { unseenCount } = useBadge();
+  const { unreadCount: notificationsUnread } = useNotificationsContext();
   const [wizardActive, setWizardActive] = useState(false);
 
   // Activate the onboarding wizard once the user has authenticated but has
@@ -123,6 +158,16 @@ function MainApp() {
           }}
         />
         <Tab.Screen
+          name="NotificationsTab"
+          component={NotificationsNavigator}
+          options={{
+            tabBarLabel: 'Inbox',
+            tabBarBadge:
+              notificationsUnread > 0 ? notificationsUnread : undefined,
+            tabBarBadgeStyle: { backgroundColor: '#58a6ff', fontSize: 10 },
+          }}
+        />
+        <Tab.Screen
           name="Settings"
           component={SettingsScreen}
           options={{
@@ -141,7 +186,9 @@ export default function App() {
     <AppProvider>
       <ConfigProvider>
         <BadgeProvider>
-          <MainApp />
+          <NotificationsProvider>
+            <MainApp />
+          </NotificationsProvider>
         </BadgeProvider>
       </ConfigProvider>
     </AppProvider>

--- a/mobile/src/context/NotificationsContext.tsx
+++ b/mobile/src/context/NotificationsContext.tsx
@@ -1,0 +1,161 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { useNotifications } from '../../../shared/hooks/useNotifications.js';
+import {
+  useNotificationRules,
+  notificationsMatchingRule,
+} from '../../../shared/hooks/useNotificationRules.js';
+import type {
+  NotificationItem,
+  NotificationRule,
+} from '../../../shared/types.js';
+import { asyncStorageAdapter } from '../storage/asyncStorageAdapter';
+import { useApp } from './AppContext';
+import { useConfigContext } from './ConfigContext';
+
+interface NotificationsContextValue {
+  notifications: NotificationItem[];
+  loading: boolean;
+  error: string | null;
+  lastRefresh: Date | null;
+  unreadCount: number;
+  refresh: () => void;
+  markThreadRead: (id: string) => Promise<void>;
+  markThreadsRead: (ids: string[]) => Promise<unknown>;
+  markAllRead: () => Promise<void>;
+  rules: NotificationRule[];
+  addRule: ReturnType<typeof useNotificationRules>['addRule'];
+  updateRule: ReturnType<typeof useNotificationRules>['updateRule'];
+  deleteRule: (id: string) => void;
+  toggleRule: (id: string) => void;
+  applyRule: (rule: NotificationRule) => Promise<unknown>;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+export function useNotificationsContext(): NotificationsContextValue {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) {
+    throw new Error(
+      'useNotificationsContext must be used within NotificationsProvider'
+    );
+  }
+  return ctx;
+}
+
+export function NotificationsProvider({ children }: { children: React.ReactNode }) {
+  const { octokit } = useApp();
+  const { config } = useConfigContext();
+
+  const {
+    rules,
+    addRule,
+    updateRule,
+    deleteRule,
+    toggleRule,
+  } = useNotificationRules({ storage: asyncStorageAdapter });
+
+  const rulesRef = useRef(rules);
+  rulesRef.current = rules;
+
+  const markThreadsReadRef = useRef<((ids: string[]) => Promise<unknown>) | null>(
+    null
+  );
+
+  const handleAfterRefresh = useCallback((fresh: NotificationItem[]) => {
+    const ids = new Set<string>();
+    for (const rule of rulesRef.current) {
+      if (!rule.enabled || !rule.autoApply) continue;
+      for (const n of notificationsMatchingRule(rule, fresh)) {
+        if (n.unread) ids.add(n.id);
+      }
+    }
+    if (ids.size > 0) {
+      void markThreadsReadRef.current?.([...ids]);
+    }
+  }, []);
+
+  const {
+    notifications,
+    loading,
+    error,
+    lastRefresh,
+    refresh,
+    markThreadRead,
+    markThreadsRead,
+    markAllRead,
+  } = useNotifications({
+    octokit,
+    enabled: config.defaults.notificationsEnabled,
+    refreshIntervalSeconds: config.defaults.notificationsRefreshInterval,
+    storage: asyncStorageAdapter,
+    onAfterRefresh: handleAfterRefresh,
+  });
+
+  markThreadsReadRef.current = markThreadsRead;
+
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => n.unread).length,
+    [notifications]
+  );
+
+  const applyRule = useCallback(
+    async (rule: NotificationRule) => {
+      const ids = notificationsMatchingRule(rule, notifications)
+        .filter((n) => n.unread)
+        .map((n) => n.id);
+      if (ids.length === 0) return;
+      await markThreadsRead(ids);
+    },
+    [notifications, markThreadsRead]
+  );
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      loading,
+      error,
+      lastRefresh,
+      unreadCount,
+      refresh,
+      markThreadRead,
+      markThreadsRead,
+      markAllRead,
+      rules,
+      addRule,
+      updateRule,
+      deleteRule,
+      toggleRule,
+      applyRule,
+    }),
+    [
+      notifications,
+      loading,
+      error,
+      lastRefresh,
+      unreadCount,
+      refresh,
+      markThreadRead,
+      markThreadsRead,
+      markAllRead,
+      rules,
+      addRule,
+      updateRule,
+      deleteRule,
+      toggleRule,
+      applyRule,
+    ]
+  );
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -5,7 +5,13 @@ export type DashboardStackParamList = {
   PRDetail: { item: PRItem };
 };
 
+export type NotificationsStackParamList = {
+  Notifications: undefined;
+  NotificationRules: undefined;
+};
+
 export type RootTabParamList = {
   Dashboard: undefined;
+  NotificationsTab: undefined;
   Settings: undefined;
 };

--- a/mobile/src/screens/NotificationRulesScreen.tsx
+++ b/mobile/src/screens/NotificationRulesScreen.tsx
@@ -1,0 +1,393 @@
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  Switch,
+} from 'react-native';
+import type {
+  NotificationRule,
+  RuleCondition,
+  RuleField,
+  RuleOp,
+} from '../../../shared/types.js';
+import {
+  BUILTIN_PRESETS,
+  notificationsMatchingRule,
+} from '../../../shared/hooks/useNotificationRules.js';
+import { useNotificationsContext } from '../context/NotificationsContext';
+
+const FIELD_OPTIONS: ReadonlyArray<{ value: RuleField; label: string }> = [
+  { value: 'title', label: 'Title' },
+  { value: 'author', label: 'Author' },
+  { value: 'repo', label: 'Repo' },
+  { value: 'reason', label: 'Reason' },
+  { value: 'subjectType', label: 'Subject type' },
+];
+
+const OP_OPTIONS: ReadonlyArray<{ value: RuleOp; label: string }> = [
+  { value: 'startsWith', label: 'starts with' },
+  { value: 'equals', label: 'equals' },
+  { value: 'contains', label: 'contains' },
+  { value: 'regex', label: 'regex' },
+];
+
+function emptyDraft(): Omit<NotificationRule, 'id' | 'createdAt'> {
+  return {
+    name: '',
+    enabled: true,
+    autoApply: false,
+    conditions: [{ field: 'title', op: 'startsWith', value: '' }],
+    action: 'mark-read',
+  };
+}
+
+function CycleButton<T>({
+  options,
+  value,
+  onChange,
+  style,
+}: {
+  options: ReadonlyArray<{ value: T; label: string }>;
+  value: T;
+  onChange: (v: T) => void;
+  style?: object;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.cycleBtn, style]}
+      onPress={() => {
+        const idx = options.findIndex((o) => o.value === value);
+        const next = options[(idx + 1) % options.length];
+        onChange(next.value);
+      }}
+    >
+      <Text style={styles.cycleText}>
+        {options.find((o) => o.value === value)?.label ?? String(value)}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+export function NotificationRulesScreen() {
+  const {
+    rules,
+    notifications,
+    addRule,
+    updateRule,
+    deleteRule,
+    toggleRule,
+    applyRule,
+  } = useNotificationsContext();
+
+  const [draft, setDraft] =
+    useState<Omit<NotificationRule, 'id' | 'createdAt'> | null>(null);
+
+  const draftMatchCount = useMemo(() => {
+    if (!draft) return 0;
+    return notificationsMatchingRule(
+      { ...draft, id: '__draft__', createdAt: new Date().toISOString() },
+      notifications
+    ).length;
+  }, [draft, notifications]);
+
+  const saveDraft = () => {
+    if (!draft) return;
+    if (!draft.name.trim() || draft.conditions.length === 0) return;
+    addRule(draft);
+    setDraft(null);
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 60 }}>
+      <Text style={styles.sectionTitle}>Add preset</Text>
+      <View style={styles.presetsRow}>
+        {BUILTIN_PRESETS.map((preset) => (
+          <TouchableOpacity
+            key={preset.name}
+            onPress={() => addRule({ ...preset })}
+            style={styles.chip}
+          >
+            <Text style={styles.chipText}>+ {preset.name}</Text>
+          </TouchableOpacity>
+        ))}
+        <TouchableOpacity
+          onPress={() => setDraft(emptyDraft())}
+          disabled={draft !== null}
+          style={[styles.chip, draft !== null && styles.chipDisabled]}
+        >
+          <Text style={styles.chipText}>+ Custom</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Text style={styles.sectionTitle}>Rules</Text>
+      {rules.length === 0 && !draft && (
+        <Text style={styles.empty}>
+          No rules yet. Add a preset above or build a custom rule.
+        </Text>
+      )}
+
+      {rules.map((rule) => {
+        const matchCount = notificationsMatchingRule(rule, notifications).length;
+        return (
+          <View key={rule.id} style={styles.ruleCard}>
+            <View style={styles.ruleHeader}>
+              <Switch
+                value={rule.enabled}
+                onValueChange={() => toggleRule(rule.id)}
+                trackColor={{ true: '#58a6ff', false: '#30363d' }}
+              />
+              <Text
+                style={[styles.ruleName, !rule.enabled && styles.ruleNameDisabled]}
+              >
+                {rule.name}
+              </Text>
+              <Text style={styles.ruleMatch}>{matchCount} match</Text>
+            </View>
+            <View style={styles.conditionsSummary}>
+              {rule.conditions.map((c, i) => (
+                <Text key={i} style={styles.conditionText}>
+                  {c.field} {c.op} "{c.value}"
+                  {i < rule.conditions.length - 1 ? ' AND ' : ''}
+                </Text>
+              ))}
+            </View>
+            <View style={styles.ruleActions}>
+              <View style={styles.autoToggleRow}>
+                <Switch
+                  value={rule.autoApply}
+                  onValueChange={(v) => updateRule(rule.id, { autoApply: v })}
+                  trackColor={{ true: '#58a6ff', false: '#30363d' }}
+                />
+                <Text style={styles.autoLabel}>Auto-apply</Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => applyRule(rule)}
+                disabled={matchCount === 0 || !rule.enabled}
+                style={[
+                  styles.applyBtn,
+                  (matchCount === 0 || !rule.enabled) && styles.applyBtnDisabled,
+                ]}
+              >
+                <Text style={styles.applyBtnText}>Apply</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => deleteRule(rule.id)}
+                style={styles.deleteBtn}
+              >
+                <Text style={styles.deleteBtnText}>Delete</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        );
+      })}
+
+      {draft && (
+        <View style={[styles.ruleCard, styles.draftCard]}>
+          <TextInput
+            style={styles.input}
+            placeholder="Rule name"
+            placeholderTextColor="#6e7681"
+            value={draft.name}
+            onChangeText={(text) =>
+              setDraft((prev) => prev && { ...prev, name: text })
+            }
+            autoFocus
+          />
+          {draft.conditions.map((cond, idx) => (
+            <View key={idx} style={styles.conditionEdit}>
+              <CycleButton
+                options={FIELD_OPTIONS}
+                value={cond.field}
+                onChange={(v) =>
+                  setDraft((prev) => {
+                    if (!prev) return prev;
+                    const next = [...prev.conditions];
+                    next[idx] = { ...next[idx], field: v };
+                    return { ...prev, conditions: next };
+                  })
+                }
+                style={{ flex: 0.3 }}
+              />
+              <CycleButton
+                options={OP_OPTIONS}
+                value={cond.op}
+                onChange={(v) =>
+                  setDraft((prev) => {
+                    if (!prev) return prev;
+                    const next = [...prev.conditions];
+                    next[idx] = { ...next[idx], op: v };
+                    return { ...prev, conditions: next };
+                  })
+                }
+                style={{ flex: 0.35 }}
+              />
+              <TextInput
+                style={[styles.input, { flex: 0.35, marginTop: 0 }]}
+                placeholder="value"
+                placeholderTextColor="#6e7681"
+                value={cond.value}
+                onChangeText={(text) =>
+                  setDraft((prev) => {
+                    if (!prev) return prev;
+                    const next = [...prev.conditions];
+                    next[idx] = { ...next[idx], value: text };
+                    return { ...prev, conditions: next };
+                  })
+                }
+              />
+            </View>
+          ))}
+          <TouchableOpacity
+            onPress={() =>
+              setDraft(
+                (prev) =>
+                  prev && {
+                    ...prev,
+                    conditions: [
+                      ...prev.conditions,
+                      { field: 'title', op: 'startsWith', value: '' } as RuleCondition,
+                    ],
+                  }
+              )
+            }
+          >
+            <Text style={styles.linkBtn}>+ Add condition (AND)</Text>
+          </TouchableOpacity>
+          <Text style={styles.ruleMatch}>
+            Would match {draftMatchCount} current
+          </Text>
+          <View style={styles.ruleActions}>
+            <TouchableOpacity onPress={() => setDraft(null)}>
+              <Text style={styles.linkBtn}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={saveDraft}
+              disabled={!draft.name.trim()}
+              style={[
+                styles.applyBtn,
+                !draft.name.trim() && styles.applyBtnDisabled,
+              ]}
+            >
+              <Text style={styles.applyBtnText}>Save</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0d1117' },
+  sectionTitle: {
+    color: '#e6edf3',
+    fontSize: 14,
+    fontWeight: '600',
+    paddingHorizontal: 14,
+    paddingTop: 14,
+    paddingBottom: 6,
+  },
+  presetsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    paddingHorizontal: 12,
+    marginBottom: 4,
+  },
+  chip: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#30363d',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginRight: 6,
+    marginBottom: 6,
+  },
+  chipDisabled: { opacity: 0.4 },
+  chipText: { color: '#e6edf3', fontSize: 12 },
+  empty: {
+    color: '#7d8590',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 13,
+  },
+  ruleCard: {
+    marginHorizontal: 12,
+    marginVertical: 4,
+    padding: 12,
+    backgroundColor: '#161b22',
+    borderWidth: 1,
+    borderColor: '#21262d',
+    borderRadius: 8,
+  },
+  draftCard: { borderColor: '#58a6ff' },
+  ruleHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  ruleName: { color: '#e6edf3', fontSize: 14, fontWeight: '600', flex: 1 },
+  ruleNameDisabled: { color: '#7d8590' },
+  ruleMatch: { color: '#6e7681', fontSize: 11 },
+  conditionsSummary: { marginTop: 6, gap: 2 },
+  conditionText: { color: '#7d8590', fontSize: 12, fontFamily: 'Menlo' },
+  conditionEdit: {
+    flexDirection: 'row',
+    gap: 6,
+    marginTop: 6,
+    alignItems: 'center',
+  },
+  ruleActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 8,
+  },
+  autoToggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginRight: 'auto',
+  },
+  autoLabel: { color: '#7d8590', fontSize: 12 },
+  applyBtn: {
+    backgroundColor: '#58a6ff',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  applyBtnDisabled: { opacity: 0.4 },
+  applyBtnText: { color: '#fff', fontSize: 12, fontWeight: '600' },
+  deleteBtn: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#f85149',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  deleteBtnText: { color: '#f85149', fontSize: 12 },
+  input: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#30363d',
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    color: '#e6edf3',
+    fontSize: 13,
+    marginTop: 6,
+  },
+  cycleBtn: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#30363d',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    justifyContent: 'center',
+  },
+  cycleText: { color: '#e6edf3', fontSize: 12 },
+  linkBtn: { color: '#58a6ff', fontSize: 12, marginTop: 8 },
+});

--- a/mobile/src/screens/NotificationsScreen.tsx
+++ b/mobile/src/screens/NotificationsScreen.tsx
@@ -1,0 +1,324 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  TouchableOpacity,
+  RefreshControl,
+  Linking,
+  ScrollView,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type {
+  NotificationItem,
+  NotificationRule,
+} from '../../../shared/types.js';
+import { matchNotifications } from '../../../shared/utils/notificationMatch.js';
+import { notificationHtmlUrl } from '../../../shared/utils/notificationHtmlUrl.js';
+import { notificationsMatchingRule } from '../../../shared/hooks/useNotificationRules.js';
+import { timeAgo } from '../../../shared/utils/timeAgo.js';
+import { useApp } from '../context/AppContext';
+import { useNotificationsContext } from '../context/NotificationsContext';
+import type { NotificationsStackParamList } from '../navigation/types';
+
+type Props = NativeStackScreenProps<NotificationsStackParamList, 'Notifications'>;
+
+function reasonLabel(reason: NotificationItem['reason']): string {
+  switch (reason) {
+    case 'review_requested': return 'review';
+    case 'ci_activity':      return 'CI';
+    case 'state_change':     return 'state';
+    case 'team_mention':     return 'team';
+    case 'security_alert':   return 'security';
+    default:                 return reason;
+  }
+}
+
+export function NotificationsScreen({ navigation }: Props) {
+  const { username } = useApp();
+  const {
+    notifications,
+    loading,
+    error,
+    refresh,
+    markThreadRead,
+    markThreadsRead,
+    rules,
+    applyRule,
+  } = useNotificationsContext();
+  // Items live in the dashboard context and aren't shared here — mobile
+  // notifications view doesn't cross-reference with the PR table list
+  // since they're on different tabs. We just compute working-set against
+  // the notifications' own metadata: authored / requested-reviewer signals
+  // aren't on the notification, so this is a no-op fallback for mobile.
+  const matches = useMemo(
+    () => matchNotifications(notifications, [], username),
+    [notifications, username]
+  );
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [unreadOnly, setUnreadOnly] = useState(true);
+
+  const visible = useMemo(() => {
+    let result = matches;
+    if (unreadOnly) result = result.filter((m) => m.notification.unread);
+    result = [...result].sort(
+      (a, b) =>
+        new Date(b.notification.updatedAt).getTime() -
+        new Date(a.notification.updatedAt).getTime()
+    );
+    return result;
+  }, [matches, unreadOnly]);
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const handlePress = useCallback(
+    async (n: NotificationItem) => {
+      // Tap = open + mark read (mirrors GitHub mobile behavior).
+      Linking.openURL(notificationHtmlUrl(n)).catch(() => {});
+      if (n.unread) await markThreadRead(n.id);
+    },
+    [markThreadRead]
+  );
+
+  const bulkMarkRead = async () => {
+    const ids = [...selectedIds];
+    clearSelection();
+    await markThreadsRead(ids);
+  };
+
+  const renderItem = useCallback(
+    ({
+      item: m,
+    }: {
+      item: ReturnType<typeof matchNotifications>[number];
+    }) => {
+      const selected = selectedIds.has(m.notification.id);
+      return (
+        <TouchableOpacity
+          onPress={() =>
+            selectedIds.size > 0
+              ? toggleSelected(m.notification.id)
+              : handlePress(m.notification)
+          }
+          onLongPress={() => toggleSelected(m.notification.id)}
+          style={[
+            styles.row,
+            selected && styles.rowSelected,
+            !m.notification.unread && styles.rowRead,
+          ]}
+        >
+          <View style={styles.rowHeader}>
+            {m.notification.unread && <View style={styles.unreadDot} />}
+            <Text
+              style={[styles.title, !m.notification.unread && styles.titleRead]}
+              numberOfLines={2}
+            >
+              {m.notification.subject.title}
+            </Text>
+          </View>
+          <View style={styles.metaRow}>
+            <Text style={styles.repo}>
+              {m.notification.repo.owner}/{m.notification.repo.name}
+            </Text>
+            {m.notification.subjectNumber != null && (
+              <Text style={styles.number}>#{m.notification.subjectNumber}</Text>
+            )}
+            <Text style={styles.reason}>{reasonLabel(m.notification.reason)}</Text>
+            <Text style={styles.time}>{timeAgo(m.notification.updatedAt)}</Text>
+          </View>
+        </TouchableOpacity>
+      );
+    },
+    [selectedIds, handlePress]
+  );
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        horizontal
+        style={styles.rulesBar}
+        contentContainerStyle={styles.rulesBarContent}
+        showsHorizontalScrollIndicator={false}
+      >
+        <TouchableOpacity
+          onPress={() => setUnreadOnly((p) => !p)}
+          style={[styles.chip, unreadOnly && styles.chipActive]}
+        >
+          <Text style={styles.chipText}>{unreadOnly ? 'Unread' : 'All'}</Text>
+        </TouchableOpacity>
+        {rules
+          .filter((r) => r.enabled)
+          .map((rule: NotificationRule) => {
+            const count = notificationsMatchingRule(rule, notifications).filter(
+              (n) => n.unread
+            ).length;
+            return (
+              <TouchableOpacity
+                key={rule.id}
+                onPress={() => applyRule(rule)}
+                disabled={count === 0}
+                style={[styles.chip, count === 0 && styles.chipDisabled]}
+              >
+                <Text style={styles.chipText}>
+                  {rule.name} ({count})
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        <TouchableOpacity
+          onPress={() => navigation.navigate('NotificationRules')}
+          style={styles.chip}
+        >
+          <Text style={styles.chipText}>⚙ Rules</Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      <FlatList
+        data={visible}
+        renderItem={renderItem}
+        keyExtractor={(m) => m.notification.id}
+        refreshControl={
+          <RefreshControl
+            refreshing={loading}
+            onRefresh={refresh}
+            tintColor="#58a6ff"
+          />
+        }
+        ListEmptyComponent={
+          !loading ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>
+                {unreadOnly ? '🎉 Inbox zero' : 'No notifications'}
+              </Text>
+              <Text style={styles.emptySubtitle}>
+                {unreadOnly
+                  ? 'No unread notifications. Pull to refresh.'
+                  : 'Pull to refresh.'}
+              </Text>
+            </View>
+          ) : null
+        }
+      />
+
+      {selectedIds.size > 0 && (
+        <View style={styles.bulkBar}>
+          <Text style={styles.bulkCount}>{selectedIds.size} selected</Text>
+          <View style={styles.bulkActions}>
+            <TouchableOpacity onPress={clearSelection}>
+              <Text style={styles.linkBtn}>Clear</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={bulkMarkRead} style={styles.primaryBtn}>
+              <Text style={styles.primaryBtnText}>
+                Mark {selectedIds.size} read
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0d1117' },
+  rulesBar: { backgroundColor: '#161b22', maxHeight: 44, flexGrow: 0 },
+  rulesBarContent: { paddingHorizontal: 12, paddingVertical: 8, gap: 6 },
+  chip: {
+    backgroundColor: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#30363d',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginRight: 6,
+  },
+  chipActive: { backgroundColor: '#1f2937', borderColor: '#58a6ff' },
+  chipDisabled: { opacity: 0.4 },
+  chipText: { color: '#e6edf3', fontSize: 12 },
+  error: {
+    color: '#f85149',
+    fontSize: 13,
+    padding: 8,
+    backgroundColor: '#f8514920',
+  },
+  row: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#21262d',
+    backgroundColor: '#0d1117',
+  },
+  rowSelected: { backgroundColor: '#1f2937' },
+  rowRead: { opacity: 0.6 },
+  rowHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#58a6ff',
+  },
+  title: { fontSize: 14, color: '#e6edf3', flex: 1 },
+  titleRead: { color: '#7d8590' },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 4,
+    flexWrap: 'wrap',
+  },
+  repo: {
+    fontSize: 11,
+    color: '#7d8590',
+    fontFamily: 'Menlo',
+  },
+  number: { fontSize: 11, color: '#6e7681' },
+  reason: {
+    fontSize: 10,
+    color: '#7d8590',
+    backgroundColor: '#21262d',
+    paddingHorizontal: 6,
+    borderRadius: 999,
+  },
+  time: { fontSize: 11, color: '#6e7681', marginLeft: 'auto' },
+  emptyState: { paddingTop: 80, alignItems: 'center' },
+  emptyTitle: { fontSize: 18, color: '#e6edf3', fontWeight: '600' },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#7d8590',
+    marginTop: 8,
+    textAlign: 'center',
+    paddingHorizontal: 40,
+  },
+  bulkBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 12,
+    backgroundColor: '#161b22',
+    borderTopWidth: 1,
+    borderTopColor: '#21262d',
+  },
+  bulkCount: { color: '#e6edf3', fontSize: 13 },
+  bulkActions: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  linkBtn: { color: '#58a6ff', fontSize: 13 },
+  primaryBtn: {
+    backgroundColor: '#58a6ff',
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  primaryBtnText: { color: '#fff', fontSize: 13, fontWeight: '600' },
+});


### PR DESCRIPTION
Phase 6 of the notifications integration (#136). **Stacked on #140** (→ #139 → #138 → #137). Brings the iOS app to feature parity with the web's Phases 2–5.

## What's here

### Context
- **`mobile/src/context/NotificationsContext.tsx`** — wraps `useNotifications` and `useNotificationRules` with the AsyncStorage adapter. Exposes `notifications`, `unreadCount`, `loading`, mark-read callbacks, rule CRUD, and an `applyRule` helper. Wires `onAfterRefresh` to run auto-apply rules on every successful poll, matching the web's Phase 5 behavior.

### Screens
- **`NotificationsScreen`** — bottom tab labeled "Inbox" with an unread badge.
  - Pull-to-refresh.
  - Horizontal scroll of enabled-rule chips with live match counts — tap to mark all matching read.
  - Tap a row → opens the thread on github.com + marks it read (mirrors GitHub's mobile-app behavior).
  - Long-press enters multi-select mode; sticky bulk-mark-read bar with selected count.
- **`NotificationRulesScreen`** — full CRUD with the three shipped presets (Dependabot bumps / Bot threads / CI activity). Mobile-friendlier UI than the web editor:
  - Field/op selectors are cycle-buttons (tap to advance) — no dropdowns, no native picker.
  - Live "Would match N current" counter while editing.
  - Per-rule auto-apply switch.
  - Reachable from a "⚙ Rules" chip on `NotificationsScreen`.

### Navigation
- `NotificationsStackParamList` covers the in-tab `Notifications` → `NotificationRules` flow.
- `RootTabParamList` gains `NotificationsTab` between `Dashboard` and `Settings`.

## Verification

- `npm test` from repo root — **320 passing**, unchanged.
- `npm run build` — clean web build (mobile changes don't affect the web bundle).
- Mobile TypeScript: new files introduce zero new errors. Pre-existing baseline errors from `expo/tsconfig.base` resolution remain (carried over from before #134, not addressed in this PR).
- Manual verification needed: `cd mobile && npx expo start --ios`, sign in with a notifications-scoped token, exercise the Inbox tab and rules editor.

## What's not here yet

- Phase 7 polish: settings UI for refresh interval and toggle, missing-scope detection.

## Closes / refs

Refs #136. Stacked on #140 → #139 → #138 → #137.