### PR TITLE
Phase 7: detect missing notifications scope and add mobile settings section

### DIFF
--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   StyleSheet,
   Alert,
+  Switch,
 } from 'react-native';
 import { useApp } from '../context/AppContext';
 import { useConfigContext } from '../context/ConfigContext';
@@ -159,6 +160,49 @@ export function SettingsScreen() {
         </View>
 
         <Text style={styles.prefHint}>Set auto-refresh to 0 to disable.</Text>
+      </View>
+
+      {/* Notifications */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Notifications</Text>
+
+        <View style={styles.prefRow}>
+          <Text style={styles.label}>Enable Inbox tab</Text>
+          <Switch
+            value={config.defaults.notificationsEnabled}
+            onValueChange={(v) => updateDefaults({ notificationsEnabled: v })}
+            trackColor={{ true: '#58a6ff', false: '#30363d' }}
+          />
+        </View>
+
+        <View style={styles.prefRow}>
+          <Text style={styles.label}>Refresh every (sec)</Text>
+          <TextInput
+            style={styles.prefInput}
+            value={String(config.defaults.notificationsRefreshInterval)}
+            onChangeText={(v) => {
+              const n = parseInt(v, 10);
+              if (!isNaN(n) && n >= 0) {
+                updateDefaults({ notificationsRefreshInterval: n });
+              }
+            }}
+            keyboardType="number-pad"
+            placeholderTextColor="#484f58"
+          />
+        </View>
+
+        <View style={styles.prefRow}>
+          <Text style={styles.label}>Highlight working set</Text>
+          <Switch
+            value={config.defaults.highlightWorkingSet}
+            onValueChange={(v) => updateDefaults({ highlightWorkingSet: v })}
+            trackColor={{ true: '#58a6ff', false: '#30363d' }}
+          />
+        </View>
+
+        <Text style={styles.prefHint}>
+          304 responses don't count against rate limit, so 60s is safe.
+        </Text>
       </View>
 
       {/* Sign out */}

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -10,5 +10,10 @@ export const STORAGE_KEYS = {
   LABEL_FILTERS: 'gh-dashboard-label-filters',
   HIDE_MY_REPLIES: 'gh-dashboard-hide-my-replies',
   NOTIFICATION_RULES: 'gh-dashboard-notification-rules',
-  NOTIFICATIONS_LAST_MODIFIED: 'gh-dashboard-notifications-last-modified',
+  // v2 bump: pre-v2 fetches sent If-Modified-Since on the paginated requests
+  // themselves, which GitHub treats as a *filter* on /notifications — so the
+  // stored Last-Modified came from a partial response and could not be reused
+  // safely. v2 sends If-Modified-Since only as a probe; ignoring the old key
+  // forces one unconditional refetch after upgrade to recover the full inbox.
+  NOTIFICATIONS_LAST_MODIFIED: 'gh-dashboard-notifications-last-modified-v2',
 } as const;

--- a/shared/github/notifications.test.ts
+++ b/shared/github/notifications.test.ts
@@ -175,8 +175,81 @@ describe('fetchNotifications', () => {
 
     await fetchNotifications(octokit, { perPage: 200 });
     expect(fn).toHaveBeenCalledWith(
-      expect.objectContaining({ per_page: 50 })
+      expect.objectContaining({ per_page: 50, page: 1 })
     );
+  });
+
+  it('paginates until a short page is returned', async () => {
+    // Page 1 full (50), page 2 full (50), page 3 partial (3) → stop.
+    // IDs must be all-digit strings; mapNotification rejects others.
+    const page1 = Array.from({ length: 50 }, (_, i) =>
+      rawNotification({ id: `1${String(i).padStart(3, '0')}` })
+    );
+    const page2 = Array.from({ length: 50 }, (_, i) =>
+      rawNotification({ id: `2${String(i).padStart(3, '0')}` })
+    );
+    const page3 = Array.from({ length: 3 }, (_, i) =>
+      rawNotification({ id: `3${String(i).padStart(3, '0')}` })
+    );
+
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: page1,
+        headers: { 'last-modified': 'Tue, 12 May 2026 10:00:00 GMT' },
+      })
+      .mockResolvedValueOnce({ data: page2, headers: {} })
+      .mockResolvedValueOnce({ data: page3, headers: {} });
+
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    const result = await fetchNotifications(octokit);
+    expect(result.notifications).toHaveLength(103);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenNthCalledWith(1, expect.objectContaining({ page: 1 }));
+    expect(fn).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }));
+    expect(fn).toHaveBeenNthCalledWith(3, expect.objectContaining({ page: 3 }));
+    // Last-Modified comes from the first page only.
+    expect(result.lastModified).toBe('Tue, 12 May 2026 10:00:00 GMT');
+  });
+
+  it('only sends If-Modified-Since on the first paginated request', async () => {
+    const page1 = Array.from({ length: 50 }, (_, i) =>
+      rawNotification({ id: `4${String(i).padStart(3, '0')}` })
+    );
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ data: page1, headers: {} })
+      .mockResolvedValueOnce({ data: [], headers: {} });
+
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await fetchNotifications(octokit, {
+      ifModifiedSince: 'Mon, 11 May 2026 09:00:00 GMT',
+    });
+
+    expect(fn.mock.calls[0][0].headers).toEqual({
+      'If-Modified-Since': 'Mon, 11 May 2026 09:00:00 GMT',
+    });
+    expect(fn.mock.calls[1][0].headers).toEqual({});
+  });
+
+  it('honors maxPages as a safety cap', async () => {
+    const fullPage = Array.from({ length: 50 }, (_, i) =>
+      rawNotification({ id: `5${String(i).padStart(3, '0')}` })
+    );
+    const fn = vi.fn().mockResolvedValue({ data: fullPage, headers: {} });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    const result = await fetchNotifications(octokit, { maxPages: 2 });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result.notifications).toHaveLength(100);
   });
 
   it('filters out unmappable entries instead of throwing', async () => {

--- a/shared/github/notifications.test.ts
+++ b/shared/github/notifications.test.ts
@@ -106,7 +106,7 @@ describe('fetchNotifications', () => {
     expect(result.notModified).toBe(false);
   });
 
-  it('sends If-Modified-Since when ifModifiedSince is provided', async () => {
+  it('sends a conditional probe with If-Modified-Since when provided', async () => {
     const fn = vi.fn().mockResolvedValue({ data: [], headers: {} });
     const octokit = mockOctokit({
       activity: { listNotificationsForAuthenticatedUser: fn },
@@ -116,14 +116,31 @@ describe('fetchNotifications', () => {
       ifModifiedSince: 'Mon, 11 May 2026 09:00:00 GMT',
     });
 
-    expect(fn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        headers: { 'If-Modified-Since': 'Mon, 11 May 2026 09:00:00 GMT' },
-      })
-    );
+    // First call is the conditional probe (per_page:1 to keep it cheap).
+    expect(fn.mock.calls[0][0]).toMatchObject({
+      per_page: 1,
+      page: 1,
+      headers: { 'If-Modified-Since': 'Mon, 11 May 2026 09:00:00 GMT' },
+    });
+    // Subsequent calls fetch the full list unconditionally.
+    expect(fn.mock.calls[1][0]).toMatchObject({ per_page: 50, page: 1 });
+    expect(fn.mock.calls[1][0].headers).toBeUndefined();
   });
 
-  it('returns notModified:true when the server responds 304', async () => {
+  it('does not send a probe when ifModifiedSince is absent', async () => {
+    const fn = vi.fn().mockResolvedValue({ data: [], headers: {} });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await fetchNotifications(octokit);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.calls[0][0]).toMatchObject({ per_page: 50, page: 1 });
+    expect(fn.mock.calls[0][0].headers).toBeUndefined();
+  });
+
+  it('returns notModified:true when the conditional probe responds 304', async () => {
     const fn = vi.fn().mockRejectedValue({ status: 304 });
     const octokit = mockOctokit({
       activity: { listNotificationsForAuthenticatedUser: fn },
@@ -138,6 +155,8 @@ describe('fetchNotifications', () => {
       lastModified: null,
       notModified: true,
     });
+    // Only the probe ran — no unconditional pagination follow-up.
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it('propagates non-304 errors (e.g. 401)', async () => {
@@ -215,27 +234,42 @@ describe('fetchNotifications', () => {
     expect(result.lastModified).toBe('Tue, 12 May 2026 10:00:00 GMT');
   });
 
-  it('only sends If-Modified-Since on the first paginated request', async () => {
+  it('on probe 200, refetches the full inbox unconditionally', async () => {
+    // Probe returns 1 thread (simulating GitHub's delta behavior).
+    // Real GitHub would return only newly-changed threads here; we
+    // discard that response and refetch unconditionally to get the
+    // full inbox.
+    const probe = rawNotification({ id: '999' });
     const page1 = Array.from({ length: 50 }, (_, i) =>
       rawNotification({ id: `4${String(i).padStart(3, '0')}` })
     );
     const fn = vi
       .fn()
-      .mockResolvedValueOnce({ data: page1, headers: {} })
+      .mockResolvedValueOnce({ data: [probe], headers: {} })
+      .mockResolvedValueOnce({ data: page1, headers: { 'last-modified': 'Tue, 12 May 2026 10:00:00 GMT' } })
       .mockResolvedValueOnce({ data: [], headers: {} });
 
     const octokit = mockOctokit({
       activity: { listNotificationsForAuthenticatedUser: fn },
     });
 
-    await fetchNotifications(octokit, {
+    const result = await fetchNotifications(octokit, {
       ifModifiedSince: 'Mon, 11 May 2026 09:00:00 GMT',
     });
 
+    // Probe + two pagination calls (page 1 full → page 2 empty → stop).
+    expect(fn).toHaveBeenCalledTimes(3);
+    // Probe carries the header; full-fetch calls don't.
     expect(fn.mock.calls[0][0].headers).toEqual({
       'If-Modified-Since': 'Mon, 11 May 2026 09:00:00 GMT',
     });
-    expect(fn.mock.calls[1][0].headers).toEqual({});
+    expect(fn.mock.calls[1][0].headers).toBeUndefined();
+    expect(fn.mock.calls[2][0].headers).toBeUndefined();
+    // The probe's single thread is discarded — only the full-fetch
+    // pages contribute to the result.
+    expect(result.notifications).toHaveLength(50);
+    expect(result.lastModified).toBe('Tue, 12 May 2026 10:00:00 GMT');
+    expect(result.notModified).toBe(false);
   });
 
   it('honors maxPages as a safety cap', async () => {

--- a/shared/github/notifications.test.ts
+++ b/shared/github/notifications.test.ts
@@ -6,6 +6,7 @@ import {
   markThreadsAsRead,
   markAllAsRead,
   mapNotification,
+  NotificationsScopeError,
 } from './notifications.js';
 
 function mockOctokit(overrides: Record<string, unknown> = {}): Octokit {
@@ -146,6 +147,24 @@ describe('fetchNotifications', () => {
     });
 
     await expect(fetchNotifications(octokit)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('wraps 403 in NotificationsScopeError', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 403, message: 'Resource not accessible by integration' });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await expect(fetchNotifications(octokit)).rejects.toBeInstanceOf(NotificationsScopeError);
+  });
+
+  it('wraps 404 in NotificationsScopeError', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 404 });
+    const octokit = mockOctokit({
+      activity: { listNotificationsForAuthenticatedUser: fn },
+    });
+
+    await expect(fetchNotifications(octokit)).rejects.toBeInstanceOf(NotificationsScopeError);
   });
 
   it('clamps perPage to 50', async () => {

--- a/shared/github/notifications.ts
+++ b/shared/github/notifications.ts
@@ -9,7 +9,14 @@ import { parseNotificationSubject } from '../utils/parseNotificationSubject.js';
 export interface FetchNotificationsOptions {
   /** Include already-read threads. Default false. */
   all?: boolean;
-  /** If set, sent as `If-Modified-Since` on the first page. A 304 response is free against the rate limit. */
+  /**
+   * Optional conditional probe timestamp. When set, we send a single
+   * `If-Modified-Since` request first; on 304 we short-circuit. On 200
+   * we discard that probe and re-fetch the full list unconditionally,
+   * because GitHub's /notifications endpoint returns *only the threads
+   * updated since that timestamp* on a 200 — not the full inbox — and
+   * pagination would stop short on the first partial page.
+   */
   ifModifiedSince?: string | null;
   /** Page size, max 50 per GitHub's limit. Default 50. */
   perPage?: number;
@@ -23,9 +30,9 @@ export interface FetchNotificationsOptions {
 
 export interface FetchNotificationsResult {
   notifications: NotificationItem[];
-  /** `Last-Modified` from the response, suitable for the next `If-Modified-Since`. */
+  /** `Last-Modified` from the response, suitable for the next conditional probe. */
   lastModified: string | null;
-  /** True when the server returned 304 (nothing changed). `notifications` will be empty. */
+  /** True when the conditional probe returned 304 (nothing changed). `notifications` will be empty. */
   notModified: boolean;
 }
 
@@ -106,24 +113,46 @@ export async function fetchNotifications(
   const maxPages = Math.max(1, options.maxPages ?? 20);
   const all = options.all ?? false;
 
+  // Conditional probe. GitHub's /notifications endpoint treats
+  // If-Modified-Since as a *filter*, not just a cache validator —
+  // a 200 response with this header set contains only threads updated
+  // since the timestamp, not the full inbox. So we use the header
+  // exclusively as a cheap "is the inbox dirty?" check: 304 ⇒ skip
+  // the work entirely; anything else ⇒ fall through and re-fetch
+  // unconditionally below.
+  if (options.ifModifiedSince) {
+    try {
+      await octokit.activity.listNotificationsForAuthenticatedUser({
+        all,
+        per_page: 1,
+        page: 1,
+        headers: { 'If-Modified-Since': options.ifModifiedSince },
+      });
+      // 200 means something changed — discard this response and refetch
+      // the full list below.
+    } catch (e) {
+      if (typeof e === 'object' && e !== null && 'status' in e) {
+        const status = (e as { status: unknown }).status;
+        if (status === 304) {
+          return { notifications: [], lastModified: null, notModified: true };
+        }
+        if (status === 403 || status === 404) {
+          throw new NotificationsScopeError(status as number);
+        }
+      }
+      throw e;
+    }
+  }
+
   try {
     const collected: NotificationItem[] = [];
     let lastModified: string | null = null;
 
     for (let page = 1; page <= maxPages; page++) {
-      // Only the first page carries If-Modified-Since. Once we know the
-      // inbox changed, subsequent pages should fetch unconditionally so
-      // we don't risk a 304 mid-pagination.
-      const headers: Record<string, string> = {};
-      if (page === 1 && options.ifModifiedSince) {
-        headers['If-Modified-Since'] = options.ifModifiedSince;
-      }
-
       const response = await octokit.activity.listNotificationsForAuthenticatedUser({
         all,
         per_page: perPage,
         page,
-        headers,
       });
 
       const raw = Array.isArray(response.data) ? response.data : [];
@@ -148,9 +177,6 @@ export async function fetchNotifications(
   } catch (e) {
     if (typeof e === 'object' && e !== null && 'status' in e) {
       const status = (e as { status: unknown }).status;
-      if (status === 304) {
-        return { notifications: [], lastModified: null, notModified: true };
-      }
       // 403 (or sometimes 404) from this endpoint nearly always means the
       // token lacks the `notifications` scope. 401 is bubbled up so the
       // existing re-auth flow handles it; everything else propagates.

--- a/shared/github/notifications.ts
+++ b/shared/github/notifications.ts
@@ -9,10 +9,16 @@ import { parseNotificationSubject } from '../utils/parseNotificationSubject.js';
 export interface FetchNotificationsOptions {
   /** Include already-read threads. Default false. */
   all?: boolean;
-  /** If set, sent as `If-Modified-Since`. A 304 response is free against the rate limit. */
+  /** If set, sent as `If-Modified-Since` on the first page. A 304 response is free against the rate limit. */
   ifModifiedSince?: string | null;
   /** Page size, max 50 per GitHub's limit. Default 50. */
   perPage?: number;
+  /**
+   * Safety cap on pages walked. Default 20 → up to 1000 threads, which covers
+   * any realistic inbox while bounding worst-case requests if GitHub keeps
+   * returning full pages.
+   */
+  maxPages?: number;
 }
 
 export interface FetchNotificationsResult {
@@ -97,29 +103,48 @@ export async function fetchNotifications(
   options: FetchNotificationsOptions = {}
 ): Promise<FetchNotificationsResult> {
   const perPage = Math.max(1, Math.min(options.perPage ?? 50, 50));
-  const headers: Record<string, string> = {};
-  if (options.ifModifiedSince) {
-    headers['If-Modified-Since'] = options.ifModifiedSince;
-  }
+  const maxPages = Math.max(1, options.maxPages ?? 20);
+  const all = options.all ?? false;
 
   try {
-    const response = await octokit.activity.listNotificationsForAuthenticatedUser({
-      all: options.all ?? false,
-      per_page: perPage,
-      headers,
-    });
+    const collected: NotificationItem[] = [];
+    let lastModified: string | null = null;
 
-    const raw = Array.isArray(response.data) ? response.data : [];
-    const notifications = raw
-      .map((n) => mapNotification(n))
-      .filter((n): n is NotificationItem => n !== null);
+    for (let page = 1; page <= maxPages; page++) {
+      // Only the first page carries If-Modified-Since. Once we know the
+      // inbox changed, subsequent pages should fetch unconditionally so
+      // we don't risk a 304 mid-pagination.
+      const headers: Record<string, string> = {};
+      if (page === 1 && options.ifModifiedSince) {
+        headers['If-Modified-Since'] = options.ifModifiedSince;
+      }
 
-    const lastModified =
-      typeof response.headers?.['last-modified'] === 'string'
-        ? response.headers['last-modified']
-        : null;
+      const response = await octokit.activity.listNotificationsForAuthenticatedUser({
+        all,
+        per_page: perPage,
+        page,
+        headers,
+      });
 
-    return { notifications, lastModified, notModified: false };
+      const raw = Array.isArray(response.data) ? response.data : [];
+      for (const n of raw) {
+        const mapped = mapNotification(n);
+        if (mapped) collected.push(mapped);
+      }
+
+      if (page === 1) {
+        lastModified =
+          typeof response.headers?.['last-modified'] === 'string'
+            ? response.headers['last-modified']
+            : null;
+      }
+
+      // Short page → last page. GitHub stops sending the `next` Link too,
+      // but length comparison is enough and doesn't require parsing Link.
+      if (raw.length < perPage) break;
+    }
+
+    return { notifications: collected, lastModified, notModified: false };
   } catch (e) {
     if (typeof e === 'object' && e !== null && 'status' in e) {
       const status = (e as { status: unknown }).status;

--- a/shared/github/notifications.ts
+++ b/shared/github/notifications.ts
@@ -24,6 +24,24 @@ export interface FetchNotificationsResult {
 }
 
 /**
+ * Thrown by fetchNotifications when GitHub returns 403/404 from the
+ * notifications endpoint, which usually means the auth token lacks the
+ * `notifications` OAuth scope. Surfaced separately from generic errors
+ * so the UI can show a "your token is missing a scope" prompt rather
+ * than a confusing "Not Found".
+ */
+export class NotificationsScopeError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(
+      'GitHub denied access to the notifications endpoint. Your token is missing the "notifications" scope — re-authenticate to grant it.'
+    );
+    this.name = 'NotificationsScopeError';
+    this.status = status;
+  }
+}
+
+/**
  * Map a raw GitHub notification thread to our internal `NotificationItem`.
  * Pulled out so it can be reused by tests and future endpoints.
  */
@@ -103,13 +121,17 @@ export async function fetchNotifications(
 
     return { notifications, lastModified, notModified: false };
   } catch (e) {
-    if (
-      typeof e === 'object' &&
-      e !== null &&
-      'status' in e &&
-      (e as { status: unknown }).status === 304
-    ) {
-      return { notifications: [], lastModified: null, notModified: true };
+    if (typeof e === 'object' && e !== null && 'status' in e) {
+      const status = (e as { status: unknown }).status;
+      if (status === 304) {
+        return { notifications: [], lastModified: null, notModified: true };
+      }
+      // 403 (or sometimes 404) from this endpoint nearly always means the
+      // token lacks the `notifications` scope. 401 is bubbled up so the
+      // existing re-auth flow handles it; everything else propagates.
+      if (status === 403 || status === 404) {
+        throw new NotificationsScopeError(status as number);
+      }
     }
     throw e;
   }

--- a/shared/hooks/useNotifications.ts
+++ b/shared/hooks/useNotifications.ts
@@ -8,6 +8,7 @@ import {
   markThreadAsRead as apiMarkThreadAsRead,
   markThreadsAsRead as apiMarkThreadsAsRead,
   markAllAsRead as apiMarkAllAsRead,
+  NotificationsScopeError,
 } from '../github/notifications.js';
 import { isAuthError } from '../github/errors.js';
 
@@ -31,6 +32,8 @@ interface UseNotificationsResult {
   loading: boolean;
   error: string | null;
   authError: boolean;
+  /** True when the token lacks the `notifications` scope. Distinct from authError so the UI can prompt for a re-auth with the right scope rather than a fresh sign-in. */
+  scopeError: boolean;
   lastRefresh: Date | null;
   /** Manually trigger a refresh (also resets the auto-refresh countdown). */
   refresh: () => void;
@@ -62,6 +65,7 @@ export function useNotifications({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [authError, setAuthError] = useState(false);
+  const [scopeError, setScopeError] = useState(false);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [refreshCounter, setRefreshCounter] = useState(0);
 
@@ -96,6 +100,7 @@ export function useNotifications({
     setLoading(true);
     setError(null);
     setAuthError(false);
+    setScopeError(false);
 
     (async () => {
       try {
@@ -126,6 +131,8 @@ export function useNotifications({
         if (cancelled) return;
         if (isAuthError(e)) {
           setAuthError(true);
+        } else if (e instanceof NotificationsScopeError) {
+          setScopeError(true);
         } else {
           setError(e instanceof Error ? e.message : 'Unknown error');
         }
@@ -236,6 +243,7 @@ export function useNotifications({
     loading,
     error,
     authError,
+    scopeError,
     lastRefresh,
     refresh,
     markThreadRead,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -24,7 +24,9 @@ export type SortDirection = 'asc' | 'desc';
 export type FilterMode = 'all' | 'failing' | 'needs-review' | 'review-requested' | 'new-activity' | 'merge-ready' | 'stale';
 export type ItemTypeFilter = 'both' | 'prs' | 'issues';
 export type OwnershipFilter = 'everyone' | 'created' | 'assigned' | 'involved';
-export type ViewMode = 'list' | 'repos' | 'help' | 'detail' | 'notifications' | 'notification-rules';
+export type ViewMode = 'list' | 'repos' | 'help' | 'detail' | 'notification-rules';
+
+export type MainTab = 'pulls' | 'notifications';
 export type ThemeMode = 'dark' | 'light' | 'system';
 
 export interface RepoFetchError {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import type { DashboardItem, NotificationItem, OwnershipFilter } from './types.js';
+import type { DashboardItem, MainTab, NotificationItem, OwnershipFilter } from './types.js';
 import { createClient, type RateLimit } from './github/client.js';
 import { isAuthError } from './github/errors.js';
 import { getToken, setToken as saveToken, clearToken } from './config.js';
@@ -31,6 +31,7 @@ import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { DetailPanel } from './components/DetailPanel.js';
 import { NotificationsView } from './components/NotificationsView.js';
 import { NotificationRulesEditor } from './components/NotificationRulesEditor.js';
+import { TabBar } from './components/TabBar.js';
 
 const OWNERSHIP_CYCLE: OwnershipFilter[] = ['created', 'assigned', 'involved', 'everyone'];
 
@@ -50,9 +51,23 @@ export function App() {
   const { visibleColumns, columnOrder, toggleColumn, reorderColumns, resetColumns } = useColumnSettings();
 
   const {
-    viewMode, setViewMode, previewItem, notificationsPinnedItem, isModalOpen,
-    openDetail, closeDetail, openRepos, openNotifications, openRules, closeModal,
+    viewMode, setViewMode, previewItem, isModalOpen,
+    openDetail, closeDetail, openRepos, openRules, closeModal,
   } = useModalState();
+
+  const [mainTab, setMainTab] = useState<MainTab>('pulls');
+  const [notificationsPinnedItem, setNotificationsPinnedItem] =
+    useState<DashboardItem | null>(null);
+
+  const openNotifications = useCallback((pinTo?: DashboardItem | null) => {
+    setNotificationsPinnedItem(pinTo ?? null);
+    setMainTab('notifications');
+  }, []);
+
+  const clearPinnedNotification = useCallback(
+    () => setNotificationsPinnedItem(null),
+    []
+  );
 
   const handleRateLimit = useCallback((rl: RateLimit) => setRateLimit(rl), []);
 
@@ -244,6 +259,8 @@ export function App() {
         (f) => f.kind === item.kind && f.id === item.id
       );
       if (idx !== -1) setCursorIndex(idx);
+      setMainTab('pulls');
+      setNotificationsPinnedItem(null);
       closeModal();
     },
     [filtered, setCursorIndex, closeModal]
@@ -318,6 +335,8 @@ export function App() {
     () => ({
       viewMode,
       setViewMode,
+      mainTab,
+      setMainTab,
       moveCursor,
       openSelected,
       previewSelected,
@@ -330,7 +349,7 @@ export function App() {
       cycleItemType,
       toggleMilestoneGrouping,
     }),
-    [viewMode, setViewMode, moveCursor, openSelected, previewSelected, cycleFilter, cycleSort, handleRefresh, cycleOwnership, cycleTheme, focusSearch, cycleItemType, toggleMilestoneGrouping]
+    [viewMode, setViewMode, mainTab, moveCursor, openSelected, previewSelected, cycleFilter, cycleSort, handleRefresh, cycleOwnership, cycleTheme, focusSearch, cycleItemType, toggleMilestoneGrouping]
   );
 
   useKeyboardShortcuts(shortcutActions);
@@ -369,59 +388,91 @@ export function App() {
         repoCount={enabledRepos.length}
         itemCount={filtered.length}
         unseenCount={unseenCount}
-        notificationsUnreadCount={notificationsUnreadCount}
         onOpenRepos={openRepos}
-        onOpenNotifications={() => openNotifications()}
         onSignOut={handleSignOut}
         onRefresh={handleRefresh}
         autoRefreshSecondsLeft={autoRefreshSecondsLeft}
         authMethod={getAuthMethod(token)}
       />
-      <FilterBar
-        active={filter}
-        onFilter={handleSetFilter}
-        ownershipFilter={ownershipFilter}
-        onSetOwnership={setOwnershipFilter}
-        username={username}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchInputRef={searchInputRef}
-        itemTypeFilter={itemTypeFilter}
-        onSetItemType={setItemTypeFilter}
-        hiddenRepos={hiddenRepos}
-        onRestoreRepo={toggleRepoByName}
-        prStateFilters={prStateFilters}
-        onTogglePRState={togglePRStateFilter}
-        labelFilters={labelFilters}
-        onToggleLabel={toggleLabelFilter}
-        onClearLabels={clearLabelFilters}
-        availableLabels={availableLabels}
-        hideMyReplies={hideMyReplies}
-        onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
-        milestoneGrouping={milestoneGrouping}
-        onToggleMilestoneGrouping={toggleMilestoneGrouping}
+      <TabBar
+        active={mainTab}
+        onChange={(tab) => {
+          if (tab === 'pulls') setNotificationsPinnedItem(null);
+          setMainTab(tab);
+        }}
+        pullsCount={filtered.length}
+        unseenCount={unseenCount}
+        notificationsUnreadCount={notificationsUnreadCount}
       />
-      <PRTable
-        items={filtered}
-        cursorIndex={cursorIndex}
-        sort={sort}
-        sortDirection={sortDirection}
-        onSort={handleSetSort}
-        onPreview={previewPR}
-        isUnseen={isUnseen}
-        getUnreadNotificationCount={getUnreadNotificationCount}
-        onOpen={markSeen}
-        onOpenNotifications={openNotifications}
-        onHideRepo={toggleRepoByName}
-        staleDays={config.defaults.staleDays}
-        visibleColumns={visibleColumns}
-        columnOrder={columnOrder}
-        onToggleColumn={toggleColumn}
-        onReorderColumns={reorderColumns}
-        onResetColumns={resetColumns}
-        milestoneGrouping={milestoneGrouping}
-      />
-      <StatusBar error={error} failedRepos={failedRepos} searchQuery={searchQuery} matchCount={filtered.length} totalCount={items.length} />
+      {mainTab === 'pulls' && (
+        <>
+          <FilterBar
+            active={filter}
+            onFilter={handleSetFilter}
+            ownershipFilter={ownershipFilter}
+            onSetOwnership={setOwnershipFilter}
+            username={username}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            searchInputRef={searchInputRef}
+            itemTypeFilter={itemTypeFilter}
+            onSetItemType={setItemTypeFilter}
+            hiddenRepos={hiddenRepos}
+            onRestoreRepo={toggleRepoByName}
+            prStateFilters={prStateFilters}
+            onTogglePRState={togglePRStateFilter}
+            labelFilters={labelFilters}
+            onToggleLabel={toggleLabelFilter}
+            onClearLabels={clearLabelFilters}
+            availableLabels={availableLabels}
+            hideMyReplies={hideMyReplies}
+            onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
+            milestoneGrouping={milestoneGrouping}
+            onToggleMilestoneGrouping={toggleMilestoneGrouping}
+          />
+          <PRTable
+            items={filtered}
+            cursorIndex={cursorIndex}
+            sort={sort}
+            sortDirection={sortDirection}
+            onSort={handleSetSort}
+            onPreview={previewPR}
+            isUnseen={isUnseen}
+            getUnreadNotificationCount={getUnreadNotificationCount}
+            onOpen={markSeen}
+            onOpenNotifications={openNotifications}
+            onHideRepo={toggleRepoByName}
+            staleDays={config.defaults.staleDays}
+            visibleColumns={visibleColumns}
+            columnOrder={columnOrder}
+            onToggleColumn={toggleColumn}
+            onReorderColumns={reorderColumns}
+            onResetColumns={resetColumns}
+            milestoneGrouping={milestoneGrouping}
+          />
+          <StatusBar error={error} failedRepos={failedRepos} searchQuery={searchQuery} matchCount={filtered.length} totalCount={items.length} />
+        </>
+      )}
+      {mainTab === 'notifications' && (
+        <NotificationsView
+          notifications={notifications}
+          loading={notificationsLoading}
+          error={notificationsError}
+          scopeError={notificationsScopeError}
+          lastRefresh={notificationsLastRefresh}
+          items={items}
+          authUser={username}
+          rules={rules}
+          onApplyRule={applyRule}
+          onOpenRules={openRules}
+          onClearPinned={notificationsPinnedItem ? clearPinnedNotification : undefined}
+          onRefresh={refreshNotifications}
+          onMarkRead={markThreadRead}
+          onMarkManyRead={markThreadsRead}
+          onJumpToItem={jumpToItem}
+          pinnedItem={notificationsPinnedItem}
+        />
+      )}
 
       {viewMode === 'help' && (
         <HelpModal onClose={closeModal} />
@@ -440,26 +491,6 @@ export function App() {
           item={previewItem}
           octokit={octokit}
           onClose={closeDetail}
-        />
-      )}
-      {viewMode === 'notifications' && (
-        <NotificationsView
-          notifications={notifications}
-          loading={notificationsLoading}
-          error={notificationsError}
-          scopeError={notificationsScopeError}
-          lastRefresh={notificationsLastRefresh}
-          items={items}
-          authUser={username}
-          rules={rules}
-          onApplyRule={applyRule}
-          onOpenRules={openRules}
-          onClose={closeModal}
-          onRefresh={refreshNotifications}
-          onMarkRead={markThreadRead}
-          onMarkManyRead={markThreadsRead}
-          onJumpToItem={jumpToItem}
-          pinnedItem={notificationsPinnedItem}
         />
       )}
       {viewMode === 'notification-rules' && (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -177,6 +177,7 @@ export function App() {
     loading: notificationsLoading,
     error: notificationsError,
     authError: notificationsAuthError,
+    scopeError: notificationsScopeError,
     lastRefresh: notificationsLastRefresh,
     refresh: refreshNotifications,
     markThreadRead,
@@ -446,6 +447,7 @@ export function App() {
           notifications={notifications}
           loading={notificationsLoading}
           error={notificationsError}
+          scopeError={notificationsScopeError}
           lastRefresh={notificationsLastRefresh}
           items={items}
           authUser={username}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,9 +8,7 @@ interface HeaderProps {
   repoCount: number;
   itemCount: number;
   unseenCount: number;
-  notificationsUnreadCount: number;
   onOpenRepos: () => void;
-  onOpenNotifications: () => void;
   onSignOut: () => void;
   onRefresh: () => void;
   autoRefreshSecondsLeft: number | null;
@@ -29,9 +27,7 @@ export function Header({
   repoCount,
   itemCount,
   unseenCount,
-  notificationsUnreadCount,
   onOpenRepos,
-  onOpenNotifications,
   onSignOut,
   onRefresh,
   autoRefreshSecondsLeft,
@@ -73,18 +69,6 @@ export function Header({
           aria-label="Refresh data"
         >
           {loading ? <span className="spinner" /> : '↻'}
-        </button>
-        <button
-          className="header-btn"
-          onClick={onOpenNotifications}
-          title="Open notifications (n)"
-        >
-          Notifications
-          {notificationsUnreadCount > 0 && (
-            <span className="notifications-trigger-badge">
-              {notificationsUnreadCount > 99 ? '99+' : notificationsUnreadCount}
-            </span>
-          )}
         </button>
         <button className="header-btn" onClick={onOpenRepos} title="Manage repos (c)">
           Repos

--- a/src/components/NotificationsView.tsx
+++ b/src/components/NotificationsView.tsx
@@ -21,7 +21,8 @@ interface NotificationsViewProps {
   rules: NotificationRule[];
   onApplyRule: (rule: NotificationRule) => Promise<unknown>;
   onOpenRules: () => void;
-  onClose: () => void;
+  /** Optional: clear the current pinned-item filter (only meaningful when `pinnedItem` is set). */
+  onClearPinned?: () => void;
   onRefresh: () => void;
   onMarkRead: (id: string) => void;
   onMarkManyRead: (ids: string[]) => Promise<unknown>;
@@ -50,7 +51,7 @@ export function NotificationsView({
   rules,
   onApplyRule,
   onOpenRules,
-  onClose,
+  onClearPinned,
   onRefresh,
   onMarkRead,
   onMarkManyRead,
@@ -149,206 +150,202 @@ export function NotificationsView({
   const unreadCount = matches.filter((m) => m.notification.unread).length;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div
-        className="notifications-modal"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label="Notifications"
-      >
-        <header className="notifications-header">
-          <div className="notifications-title-block">
-            <h2 className="notifications-title">Notifications</h2>
-            <span className="notifications-count">
-              {unreadCount} unread · {matches.length} total
+    <section className="notifications-pane" aria-label="Notifications">
+      <header className="notifications-header">
+        <div className="notifications-title-block">
+          <h2 className="notifications-title">Notifications</h2>
+          <span className="notifications-count">
+            {unreadCount} unread · {matches.length} total
+          </span>
+          {pinnedItem && (
+            <span
+              className="notifications-pinned-chip"
+              title="Filtered to this PR/issue"
+            >
+              {pinnedItem.repo.owner}/{pinnedItem.repo.name}#{pinnedItem.number}
+              {onClearPinned && (
+                <button
+                  type="button"
+                  className="notifications-pinned-clear"
+                  onClick={onClearPinned}
+                  aria-label="Clear pinned filter"
+                  title="Clear pinned filter"
+                >
+                  ×
+                </button>
+              )}
             </span>
-            {pinnedItem && (
-              <span
-                className="notifications-pinned-chip"
-                title="Filtered to this PR — clear by closing and reopening from the header"
-              >
-                {pinnedItem.repo.owner}/{pinnedItem.repo.name}#{pinnedItem.number}
-              </span>
-            )}
-          </div>
-          <div className="notifications-header-actions">
-            {lastRefresh && (
-              <span className="notifications-last-refresh" title="Last refreshed">
-                {lastRefresh.toLocaleTimeString()}
-              </span>
-            )}
-            <button
-              className="notifications-icon-btn"
-              onClick={onRefresh}
-              disabled={loading}
-              title="Refresh"
-              aria-label="Refresh"
-            >
-              {loading ? <span className="spinner" /> : '↻'}
-            </button>
-            <button
-              className="notifications-icon-btn"
-              onClick={onClose}
-              title="Close (Esc)"
-              aria-label="Close"
-            >
-              ×
-            </button>
-          </div>
-        </header>
-
-        <div className="notifications-toolbar">
-          <input
-            type="text"
-            className="notifications-search"
-            placeholder="Search title, repo, #number…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-          <div className="notifications-reason-filters">
-            {REASON_FILTERS.map(({ label, reason }) => (
-              <button
-                key={reason}
-                className={
-                  'notifications-chip' +
-                  (reasonFilter === reason ? ' notifications-chip-active' : '')
-                }
-                onClick={() => setReasonFilter(reason)}
-                type="button"
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-          <label className="notifications-toggle">
-            <input
-              type="checkbox"
-              checked={unreadOnly}
-              onChange={(e) => setUnreadOnly(e.target.checked)}
-            />
-            Unread only
-          </label>
-          <button
-            className="notifications-link-btn"
-            onClick={selectAllVisible}
-            type="button"
-            disabled={filtered.length === 0}
-          >
-            {filtered.every((m) => selectedIds.has(m.notification.id)) &&
-            filtered.length > 0
-              ? 'Clear selection'
-              : 'Select all visible'}
-          </button>
-        </div>
-
-        {rules.length > 0 && (
-          <div className="notifications-rules-bar">
-            <span className="rules-presets-label">Rules:</span>
-            {rules
-              .filter((r) => r.enabled)
-              .map((rule) => {
-                const matchCount = notificationsMatchingRule(rule, notifications).length;
-                return (
-                  <button
-                    key={rule.id}
-                    type="button"
-                    className="notifications-chip"
-                    onClick={() => onApplyRule(rule)}
-                    disabled={matchCount === 0}
-                    title={rule.conditions
-                      .map((c) => `${c.field} ${c.op} "${c.value}"`)
-                      .join(' AND ')}
-                  >
-                    {rule.name}{' '}
-                    <span className="rule-chip-count">({matchCount})</span>
-                  </button>
-                );
-              })}
-            <button
-              type="button"
-              className="notifications-link-btn"
-              onClick={onOpenRules}
-            >
-              Edit rules
-            </button>
-          </div>
-        )}
-        {rules.length === 0 && (
-          <div className="notifications-rules-bar">
-            <span className="rules-presets-label notifications-muted">
-              No rules yet —
-            </span>
-            <button
-              type="button"
-              className="notifications-link-btn"
-              onClick={onOpenRules}
-            >
-              Add a rule to bulk-mark common noise
-            </button>
-          </div>
-        )}
-
-        {scopeError && (
-          <div className="notifications-error" role="alert">
-            Your GitHub token can't read notifications. Sign out and re-authenticate
-            with the <code>notifications</code> scope to enable this view.
-          </div>
-        )}
-        {error && !scopeError && (
-          <div className="notifications-error" role="alert">
-            {error}
-          </div>
-        )}
-
-        <div className="notifications-list">
-          {filtered.length === 0 ? (
-            <div className="notifications-empty">
-              {loading
-                ? 'Loading…'
-                : unreadCount === 0
-                ? '🎉 Inbox zero — no unread notifications.'
-                : 'No notifications match the current filters.'}
-            </div>
-          ) : (
-            filtered.map((m) => (
-              <NotificationRow
-                key={m.notification.id}
-                notification={m.notification}
-                matchedItem={m.item}
-                isWorkingSet={m.isWorkingSet}
-                selected={selectedIds.has(m.notification.id)}
-                onToggleSelected={toggleSelected}
-                onMarkRead={onMarkRead}
-                onJumpToItem={onJumpToItem}
-              />
-            ))
           )}
         </div>
-
-        {selectedIds.size > 0 && (
-          <footer className="notifications-bulk-bar" role="region" aria-label="Bulk actions">
-            <span>
-              {selectedIds.size} selected
+        <div className="notifications-header-actions">
+          {lastRefresh && (
+            <span className="notifications-last-refresh" title="Last refreshed">
+              {lastRefresh.toLocaleTimeString()}
             </span>
-            <div className="notifications-bulk-actions">
-              <button
-                className="notifications-link-btn"
-                onClick={clearSelection}
-                type="button"
-              >
-                Clear
-              </button>
-              <button
-                className="notifications-primary-btn"
-                onClick={handleBulkMarkRead}
-                type="button"
-              >
-                Mark {selectedIds.size} as read
-              </button>
-            </div>
-          </footer>
+          )}
+          <button
+            className="notifications-icon-btn"
+            onClick={onRefresh}
+            disabled={loading}
+            title="Refresh"
+            aria-label="Refresh"
+          >
+            {loading ? <span className="spinner" /> : '↻'}
+          </button>
+        </div>
+      </header>
+
+      <div className="notifications-toolbar">
+        <input
+          type="text"
+          className="notifications-search"
+          placeholder="Search title, repo, #number…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className="notifications-reason-filters">
+          {REASON_FILTERS.map(({ label, reason }) => (
+            <button
+              key={reason}
+              className={
+                'notifications-chip' +
+                (reasonFilter === reason ? ' notifications-chip-active' : '')
+              }
+              onClick={() => setReasonFilter(reason)}
+              type="button"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <label className="notifications-toggle">
+          <input
+            type="checkbox"
+            checked={unreadOnly}
+            onChange={(e) => setUnreadOnly(e.target.checked)}
+          />
+          Unread only
+        </label>
+        <button
+          className="notifications-link-btn"
+          onClick={selectAllVisible}
+          type="button"
+          disabled={filtered.length === 0}
+        >
+          {filtered.every((m) => selectedIds.has(m.notification.id)) &&
+          filtered.length > 0
+            ? 'Clear selection'
+            : 'Select all visible'}
+        </button>
+      </div>
+
+      {rules.length > 0 && (
+        <div className="notifications-rules-bar">
+          <span className="rules-presets-label">Rules:</span>
+          {rules
+            .filter((r) => r.enabled)
+            .map((rule) => {
+              const matchCount = notificationsMatchingRule(rule, notifications).length;
+              return (
+                <button
+                  key={rule.id}
+                  type="button"
+                  className="notifications-chip"
+                  onClick={() => onApplyRule(rule)}
+                  disabled={matchCount === 0}
+                  title={rule.conditions
+                    .map((c) => `${c.field} ${c.op} "${c.value}"`)
+                    .join(' AND ')}
+                >
+                  {rule.name}{' '}
+                  <span className="rule-chip-count">({matchCount})</span>
+                </button>
+              );
+            })}
+          <button
+            type="button"
+            className="notifications-link-btn"
+            onClick={onOpenRules}
+          >
+            Edit rules
+          </button>
+        </div>
+      )}
+      {rules.length === 0 && (
+        <div className="notifications-rules-bar">
+          <span className="rules-presets-label notifications-muted">
+            No rules yet —
+          </span>
+          <button
+            type="button"
+            className="notifications-link-btn"
+            onClick={onOpenRules}
+          >
+            Add a rule to bulk-mark common noise
+          </button>
+        </div>
+      )}
+
+      {scopeError && (
+        <div className="notifications-error" role="alert">
+          Your GitHub token can't read notifications. Sign out and re-authenticate
+          with the <code>notifications</code> scope to enable this view.
+        </div>
+      )}
+      {error && !scopeError && (
+        <div className="notifications-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className="notifications-list">
+        {filtered.length === 0 ? (
+          <div className="notifications-empty">
+            {loading
+              ? 'Loading…'
+              : unreadCount === 0
+              ? '🎉 Inbox zero — no unread notifications.'
+              : 'No notifications match the current filters.'}
+          </div>
+        ) : (
+          filtered.map((m) => (
+            <NotificationRow
+              key={m.notification.id}
+              notification={m.notification}
+              matchedItem={m.item}
+              isWorkingSet={m.isWorkingSet}
+              selected={selectedIds.has(m.notification.id)}
+              onToggleSelected={toggleSelected}
+              onMarkRead={onMarkRead}
+              onJumpToItem={onJumpToItem}
+            />
+          ))
         )}
       </div>
-    </div>
+
+      {selectedIds.size > 0 && (
+        <footer className="notifications-bulk-bar" role="region" aria-label="Bulk actions">
+          <span>
+            {selectedIds.size} selected
+          </span>
+          <div className="notifications-bulk-actions">
+            <button
+              className="notifications-link-btn"
+              onClick={clearSelection}
+              type="button"
+            >
+              Clear
+            </button>
+            <button
+              className="notifications-primary-btn"
+              onClick={handleBulkMarkRead}
+              type="button"
+            >
+              Mark {selectedIds.size} as read
+            </button>
+          </div>
+        </footer>
+      )}
+    </section>
   );
 }

--- a/src/components/NotificationsView.tsx
+++ b/src/components/NotificationsView.tsx
@@ -13,6 +13,7 @@ interface NotificationsViewProps {
   notifications: NotificationItem[];
   loading: boolean;
   error: string | null;
+  scopeError: boolean;
   lastRefresh: Date | null;
   /** All fetched PRs/issues — used to cross-reference and to derive working-set membership. */
   items: DashboardItem[];
@@ -42,6 +43,7 @@ export function NotificationsView({
   notifications,
   loading,
   error,
+  scopeError,
   lastRefresh,
   items,
   authUser,
@@ -286,7 +288,13 @@ export function NotificationsView({
           </div>
         )}
 
-        {error && (
+        {scopeError && (
+          <div className="notifications-error" role="alert">
+            Your GitHub token can't read notifications. Sign out and re-authenticate
+            with the <code>notifications</code> scope to enable this view.
+          </div>
+        )}
+        {error && !scopeError && (
           <div className="notifications-error" role="alert">
             {error}
           </div>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { MainTab } from '../types.js';
+
+interface TabBarProps {
+  active: MainTab;
+  onChange: (tab: MainTab) => void;
+  pullsCount: number;
+  unseenCount: number;
+  notificationsUnreadCount: number;
+}
+
+export function TabBar({
+  active,
+  onChange,
+  pullsCount,
+  unseenCount,
+  notificationsUnreadCount,
+}: TabBarProps) {
+  return (
+    <div className="tab-bar" role="tablist" aria-label="Main views">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active === 'pulls'}
+        className={'tab' + (active === 'pulls' ? ' tab-active' : '')}
+        onClick={() => onChange('pulls')}
+      >
+        <span className="tab-label">Pull Requests &amp; Issues</span>
+        <span className="tab-count">{pullsCount}</span>
+        {unseenCount > 0 && (
+          <span className="tab-badge" title={`${unseenCount} with new activity`}>
+            {unseenCount > 99 ? '99+' : unseenCount} new
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active === 'notifications'}
+        className={'tab' + (active === 'notifications' ? ' tab-active' : '')}
+        onClick={() => onChange('notifications')}
+      >
+        <span className="tab-label">Notifications</span>
+        {notificationsUnreadCount > 0 && (
+          <span className="tab-badge" title={`${notificationsUnreadCount} unread`}>
+            {notificationsUnreadCount > 99 ? '99+' : notificationsUnreadCount}
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts.js';
-import type { ViewMode } from '../types.js';
+import type { MainTab, ViewMode } from '../types.js';
 
 function makeActions() {
   return {
     viewMode: 'list' as ViewMode,
     setViewMode: vi.fn(),
+    mainTab: 'pulls' as MainTab,
+    setMainTab: vi.fn(),
     moveCursor: vi.fn(),
     openSelected: vi.fn(),
     previewSelected: vi.fn(),

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
-import type { ViewMode } from '../types.js';
+import type { MainTab, ViewMode } from '../types.js';
 
 interface ShortcutActions {
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
+  mainTab: MainTab;
+  setMainTab: (tab: MainTab) => void;
   moveCursor: (delta: number) => void;
   openSelected: () => void;
   previewSelected: () => void;
@@ -29,7 +31,29 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
         return;
       }
 
-      const { viewMode, setViewMode } = actions;
+      const { viewMode, setViewMode, mainTab, setMainTab } = actions;
+
+      // `n` toggles between the pulls and notifications tabs from any non-modal state.
+      if (viewMode === 'list' && (e.key === 'n' || e.key === 'N')) {
+        e.preventDefault();
+        setMainTab(mainTab === 'notifications' ? 'pulls' : 'notifications');
+        return;
+      }
+
+      // Most PR-list shortcuts are inert while the notifications tab is foregrounded;
+      // it has its own filters/search and doesn't have a cursor to move.
+      if (viewMode === 'list' && mainTab === 'notifications') {
+        if (e.key === '?') {
+          setViewMode('help');
+        } else if (e.key === 'r') {
+          actions.refresh();
+        } else if (e.key === 'T') {
+          actions.cycleTheme();
+        } else if (e.key === 'c') {
+          setViewMode('repos');
+        }
+        return;
+      }
 
       if (viewMode === 'help') {
         if (e.key === '?' || e.key === 'Escape') {

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -4,9 +4,6 @@ import type { ViewMode, DashboardItem } from '../types.js';
 export function useModalState() {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [previewItem, setPreviewItem] = useState<DashboardItem | null>(null);
-  /** PR/issue the notifications view should be pre-filtered to (set via the PR table indicator). */
-  const [notificationsPinnedItem, setNotificationsPinnedItem] =
-    useState<DashboardItem | null>(null);
 
   const isModalOpen = viewMode !== 'list';
 
@@ -22,28 +19,21 @@ export function useModalState() {
 
   const openRepos = useCallback(() => setViewMode('repos'), []);
   const openHelp = useCallback(() => setViewMode('help'), []);
-  const openNotifications = useCallback((pinTo?: DashboardItem | null) => {
-    setNotificationsPinnedItem(pinTo ?? null);
-    setViewMode('notifications');
-  }, []);
   const openRules = useCallback(() => setViewMode('notification-rules'), []);
   const closeModal = useCallback(() => {
     setViewMode('list');
     setPreviewItem(null);
-    setNotificationsPinnedItem(null);
   }, []);
 
   return {
     viewMode,
     setViewMode,
     previewItem,
-    notificationsPinnedItem,
     isModalOpen,
     openDetail,
     closeDetail,
     openRepos,
     openHelp,
-    openNotifications,
     openRules,
     closeModal,
   };

--- a/src/styles/Notifications.css
+++ b/src/styles/Notifications.css
@@ -1,5 +1,6 @@
 /* ── Notifications view ─────────────────────────────────────── */
 
+/* Modal variant — still used by the NotificationRulesEditor. */
 .notifications-modal {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -9,6 +10,34 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* Full-pane variant — the notifications tab fills the main content area. */
+.notifications-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+
+.notifications-pinned-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 4px;
+  margin-left: 4px;
+  line-height: 1;
+}
+
+.notifications-pinned-clear:hover {
+  color: var(--text);
 }
 
 .notifications-header {
@@ -351,17 +380,54 @@
   opacity: 0.9;
 }
 
-/* Header badge for opening the notifications view */
-.notifications-trigger-badge {
+/* ── Main tab bar (Pulls / Notifications) ─────────────────── */
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 0 0 0;
+  margin-top: 4px;
+}
+
+.tab {
+  position: relative;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.tab:hover {
+  color: var(--text);
+}
+
+.tab-active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+.tab-count {
+  color: var(--text-subtle);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tab-badge {
   background: var(--accent);
   color: #fff;
   font-size: 10px;
   font-weight: 600;
   border-radius: 999px;
-  padding: 0 6px;
-  margin-left: 6px;
-  min-width: 16px;
-  text-align: center;
+  padding: 1px 7px;
+  letter-spacing: 0.02em;
 }
 
 /* Rules quick-action bar inside NotificationsView */

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type {
   ItemTypeFilter,
   OwnershipFilter,
   ViewMode,
+  MainTab,
   ThemeMode,
   RepoFetchError,
   ReviewState,


### PR DESCRIPTION
Final phase of the notifications integration (#136). **Stacked on #141** (→ #140 → #139 → #138 → #137).

## What's here

### Missing-scope detection
GitHub returns **403** (or sometimes 404) from `/notifications` when the auth token lacks the `notifications` scope. Generic 404 error messages aren't actionable, so we now:

- `fetchNotifications` wraps 403/404 in a new `NotificationsScopeError` (exported), distinguishable from generic transport errors and from 401 (which keeps using the existing re-auth flow).
- `useNotifications` exposes a separate `scopeError` boolean alongside `authError`.
- `NotificationsView` renders a specific banner directing the user to sign out and re-authenticate with the `notifications` scope, rather than the generic error message.

### Mobile settings section
`SettingsScreen` gains a **Notifications** section with:

- **Enable Inbox tab** — toggle for `config.defaults.notificationsEnabled`.
- **Refresh every (sec)** — input bound to `notificationsRefreshInterval` (0 disables polling).
- **Highlight working set** — toggle for `highlightWorkingSet`.
- Hint: "304 responses don't count against rate limit, so 60s is safe."

### Tests
- +2 cases covering 403 and 404 → `NotificationsScopeError` wrapping.
- **322 passing** total (was 320).

## Verification

- `npm test` — 322 passing.
- `npm run build` — clean.
- Manual scope check: revoke the `notifications` scope on the token; the NotificationsView should show the specific scope-error banner rather than a generic "Not Found".

## Closes / refs

Refs #136. Stacked on #141 → #140 → #139 → #138 → #137.

This completes the original plan. After this stack merges, every checkbox on #136 is checked.