### PR TITLE
Fix scroll jumping back to top on auto-refresh (#143)

### DIFF
--- a/src/components/PRTable.tsx
+++ b/src/components/PRTable.tsx
@@ -36,6 +36,7 @@ interface PRTableProps {
 
 export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPreview, isUnseen, onOpen, onHideRepo, staleDays, visibleColumns, columnOrder, onToggleColumn, onReorderColumns, onResetColumns, milestoneGrouping }: PRTableProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const prevCursorIndexRef = useRef<number | null>(null);
   const { isCollapsed, toggle } = useMilestoneCollapse();
 
   const milestoneGroups = useMemo(
@@ -77,13 +78,17 @@ export function PRTable({ items, cursorIndex, sort, sortDirection, onSort, onPre
     overscan: 10,
   });
 
-  // Scroll to keep the selected row visible when cursor moves
+  // Scroll to keep the selected row visible when the cursor moves.
+  // Only scroll when cursorIndex actually changes — otherwise auto-refresh
+  // (which gives `items` and `groupedRows` new identities) would yank the
+  // viewport back to the selected row on every refresh tick.
   useEffect(() => {
+    if (prevCursorIndexRef.current === cursorIndex) return;
+    prevCursorIndexRef.current = cursorIndex;
+
     if (milestoneGrouping) {
-      // In grouped mode, map cursorIndex to the visible row index
       const visibleIdx = flatToVisibleIndex.get(cursorIndex);
       if (visibleIdx !== undefined) {
-        // Account for milestone header rows preceding this visible item
         let rowIdx = 0;
         let itemsSeen = 0;
         for (const entry of groupedRows) {


### PR DESCRIPTION
Closes #143.

## Summary

The PR/issues table snapped back to the top every auto-refresh tick, making it impossible to scroll past the initial window.

`PRTable.tsx`'s scroll-to-cursor effect listed `items.length`, `groupedRows`, etc. in its dependency array. Auto-refresh hands those references new identities even when nothing changed, so the effect re-ran and called `virtualizer.scrollToIndex(cursorIndex, { align: 'auto' })`. Since `cursorIndex` defaults to `0` and only moves on `j`/`k`, that call repeatedly scrolled the viewport back to row 0.

## Fix

Track the previous `cursorIndex` in a ref and bail out of the effect when it hasn't changed, so the virtualizer only scrolls in response to actual user navigation.

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 267/267 passing
- [ ] Manually scroll the dashboard past the visible window and confirm it stays put across an auto-refresh
- [ ] Press `j`/`k` and confirm the cursor still scrolls into view
- [ ] Toggle milestone grouping and confirm cursor-follow still works there too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary scroll jumps when refreshing table data while maintaining row selection in grouped views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/landingit/pull/144)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->