### PR TITLE
Bump version to 2.0.0 for notifications release

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "LandinGit",
     "slug": "landingit",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "landingit",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "landingit",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landingit",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "LandinGit — the keyboard-first GitHub PR dashboard",
   "author": {
     "name": "Adam Silverstein",


### PR DESCRIPTION
## Summary

The GitHub notifications integration (#136) just landed across PRs #137–#142 — it adds a desktop inbox tab, a mobile Inbox tab, configurable rules with auto-apply, and a PR-table indicator linking the two surfaces. That's a significant enough feature to warrant a major version bump.

Bumps:
- `package.json`: `1.0.2` → `2.0.0`
- `mobile/package.json`: `1.0.0` → `2.0.0`
- `mobile/app.json` (Expo `version`): `1.0.0` → `2.0.0`
- `package-lock.json`: regenerated to match

Note: `mobile/ios/GitDashboard/Info.plist` is gitignored — it regenerates from `app.json` on the next `expo prebuild`. The mobile `buildNumber`/`CFBundleVersion` is left at `1`; bump it separately when submitting the next TestFlight build.

## Test plan

- [x] `npm test` — 326 passing
- [x] `npm run build` — clean
- [ ] On next mobile release, run `expo prebuild` and verify `CFBundleShortVersionString` ends up at `2.0.0`