### PR TITLE
Bump iOS buildNumber to 2

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.github.adamsilverstein.landingit",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }


### PR DESCRIPTION
## Summary

Bumps `mobile/app.json` `ios.buildNumber` from `1` to `2` ahead of the next TestFlight submission under 2.0.0. Apple requires `CFBundleVersion` to be unique per `CFBundleShortVersionString` within a track; build 1 already shipped under 1.0.0.

The matching `CFBundleVersion` in `mobile/ios/GitDashboard/Info.plist` is gitignored and will pick this up on the next `expo prebuild`.

## Test plan

- [ ] Run `cd mobile && expo prebuild` and confirm `CFBundleVersion=2` in the regenerated Info.plist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build version number.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/landingit/pull/146)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->