### PR TITLE
Skip EAS build steps when EXPO_TOKEN is missing

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -31,18 +31,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check for EXPO_TOKEN
+        id: expo-token
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -n "$EXPO_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::EXPO_TOKEN is not configured — EAS build steps will be skipped. Add the secret to enable iOS builds."
+          fi
+
       - name: Setup EAS
+        if: steps.expo-token.outputs.present == 'true'
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Build preview (push to main)
-        if: github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+        if: steps.expo-token.outputs.present == 'true' && github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         run: eas build --platform ios --profile preview --non-interactive
 
       - name: Build and submit to App Store (version tag)
-        if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-ios')
+        if: steps.expo-token.outputs.present == 'true' && startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-ios')
         run: eas build --platform ios --profile production --auto-submit --non-interactive
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}


### PR DESCRIPTION
## Problem

Every push to main with a `mobile/**` or `shared/**` change has been failing the **Build iOS App** workflow since at least May 4 — the run history shows 10 straight failures. Root cause: the repo has zero secrets configured, so `${{ secrets.EXPO_TOKEN }}` resolves to an empty string and `eas build` exits with:

> An Expo user account is required to proceed. Either log in with eas login or set the EXPO_TOKEN environment variable…

Most recent: [run #25922775109](https://github.com/adamsilverstein/landingit/actions/runs/25922775109) (triggered by the buildNumber bump in #146).

## Fix

A new "Check for EXPO_TOKEN" step exposes the secret's presence as a step output (`steps.expo-token.outputs.present`). The three EAS-dependent steps (`Setup EAS`, `Build preview`, `Build and submit to App Store`) gate on it. When the token is missing the workflow emits a workflow-level warning annotation and the remaining steps no-op, so the run completes ✓ instead of ✗.

The `Verify Web App` job is unaffected — it doesn't need the token and was already passing.

## Re-enabling iOS builds

To turn EAS builds back on, generate a token at https://expo.dev/settings/access-tokens and:

```
gh secret set EXPO_TOKEN --repo adamsilverstein/landingit
```

Once set, the workflow detects it automatically on the next run.

## Test plan

- [x] YAML lints cleanly (no syntax errors)
- [ ] After merge, confirm the next push to main shows the workflow succeeding with a warning annotation rather than failing
- [ ] When `EXPO_TOKEN` is eventually added, confirm the preview build runs again