### PR TITLE
Auto-hide top header on scroll for mobile screens (#148)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer, DarkTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -51,7 +52,7 @@ function DashboardNavigator() {
       <DashboardStack.Screen
         name="PRList"
         component={PRListScreen}
-        options={{ title: 'Pull Requests' }}
+        options={{ title: 'Pull Requests', headerShown: false }}
       />
       <DashboardStack.Screen
         name="PRDetail"
@@ -74,7 +75,7 @@ function NotificationsNavigator() {
       <NotificationsStack.Screen
         name="Notifications"
         component={NotificationsScreen}
-        options={{ title: 'Notifications' }}
+        options={{ title: 'Notifications', headerShown: false }}
       />
       <NotificationsStack.Screen
         name="NotificationRules"
@@ -183,15 +184,17 @@ function MainApp() {
 
 export default function App() {
   return (
-    <AppProvider>
-      <ConfigProvider>
-        <BadgeProvider>
-          <NotificationsProvider>
-            <MainApp />
-          </NotificationsProvider>
-        </BadgeProvider>
-      </ConfigProvider>
-    </AppProvider>
+    <SafeAreaProvider>
+      <AppProvider>
+        <ConfigProvider>
+          <BadgeProvider>
+            <NotificationsProvider>
+              <MainApp />
+            </NotificationsProvider>
+          </BadgeProvider>
+        </ConfigProvider>
+      </AppProvider>
+    </SafeAreaProvider>
   );
 }
 

--- a/mobile/src/components/AutoHidingHeader.tsx
+++ b/mobile/src/components/AutoHidingHeader.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { NAV_BAR_HEIGHT } from '../hooks/useAutoHidingHeader';
+
+interface Props {
+  title: string;
+  translateY: Animated.Value;
+  statusBarHeight: number;
+}
+
+/**
+ * Overlay header that mimics the React Navigation native-stack header but can
+ * animate offscreen on scroll. The status-bar inset is always rendered so the
+ * battery/clock area has an opaque background even while the title slides
+ * away.
+ */
+export function AutoHidingHeader({ title, translateY, statusBarHeight }: Props) {
+  return (
+    <View
+      style={[styles.container, { height: statusBarHeight + NAV_BAR_HEIGHT }]}
+      pointerEvents="box-none"
+    >
+      <Animated.View
+        style={[
+          styles.navBar,
+          {
+            top: statusBarHeight,
+            transform: [{ translateY }],
+          },
+        ]}
+      >
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+      </Animated.View>
+      {/* Render the status-bar inset last so it sits above the navBar and
+          hides the title when the navBar slides up behind it. */}
+      <View style={[styles.statusBar, { height: statusBarHeight }]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+  },
+  statusBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: '#161b22',
+  },
+  navBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: NAV_BAR_HEIGHT,
+    backgroundColor: '#161b22',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#21262d',
+  },
+  title: {
+    color: '#e6edf3',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/components/AutoHidingHeader.tsx
+++ b/mobile/src/components/AutoHidingHeader.tsx
@@ -29,7 +29,11 @@ export function AutoHidingHeader({ title, translateY, statusBarHeight }: Props) 
           },
         ]}
       >
-        <Text style={styles.title} numberOfLines={1}>
+        <Text
+          style={styles.title}
+          numberOfLines={1}
+          accessibilityRole="header"
+        >
           {title}
         </Text>
       </Animated.View>

--- a/mobile/src/hooks/useAutoHidingHeader.ts
+++ b/mobile/src/hooks/useAutoHidingHeader.ts
@@ -1,0 +1,79 @@
+import { useCallback, useRef } from 'react';
+import { Animated } from 'react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// Standard iOS navigation bar height. Excludes the status-bar inset, which is
+// added separately via the safe-area top inset so the nav bar sits below the
+// notch/dynamic island.
+export const NAV_BAR_HEIGHT = 44;
+
+// Minimum pixel delta before we react. Small touches (tap, finger jitter) can
+// fire scroll events with tiny deltas; ignoring them prevents the header from
+// flickering when the user isn't actually intending to scroll.
+const SCROLL_THRESHOLD = 6;
+
+/**
+ * Drives the auto-hiding nav bar: shows when the user scrolls up, hides when
+ * scrolling down past a small threshold, and always shows when near the top.
+ *
+ * Returns the animated translateY that both the header overlay and the
+ * scrolling content wrapper should bind to, along with the onScroll handler to
+ * attach to the FlatList/ScrollView.
+ */
+export function useAutoHidingHeader() {
+  const insets = useSafeAreaInsets();
+
+  // Status-bar inset stays visible; only the nav bar slides offscreen.
+  const navBarHeight = NAV_BAR_HEIGHT;
+  const statusBarHeight = insets.top;
+
+  const translateY = useRef(new Animated.Value(0)).current;
+  const prevScrollY = useRef(0);
+  const hidden = useRef(false);
+
+  const onScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const y = e.nativeEvent.contentOffset.y;
+      const delta = y - prevScrollY.current;
+      prevScrollY.current = y;
+
+      if (y <= 0) {
+        if (hidden.current) {
+          Animated.timing(translateY, {
+            toValue: 0,
+            duration: 180,
+            useNativeDriver: true,
+          }).start();
+          hidden.current = false;
+        }
+        return;
+      }
+
+      if (delta > SCROLL_THRESHOLD && !hidden.current) {
+        Animated.timing(translateY, {
+          toValue: -navBarHeight,
+          duration: 200,
+          useNativeDriver: true,
+        }).start();
+        hidden.current = true;
+      } else if (delta < -SCROLL_THRESHOLD && hidden.current) {
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: 150,
+          useNativeDriver: true,
+        }).start();
+        hidden.current = false;
+      }
+    },
+    [translateY, navBarHeight]
+  );
+
+  return {
+    translateY,
+    navBarHeight,
+    statusBarHeight,
+    totalHeaderHeight: statusBarHeight + navBarHeight,
+    onScroll,
+  };
+}

--- a/mobile/src/screens/NotificationsScreen.tsx
+++ b/mobile/src/screens/NotificationsScreen.tsx
@@ -8,6 +8,7 @@ import {
   RefreshControl,
   Linking,
   ScrollView,
+  Animated,
 } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type {
@@ -20,6 +21,8 @@ import { notificationsMatchingRule } from '../../../shared/hooks/useNotification
 import { timeAgo } from '../../../shared/utils/timeAgo.js';
 import { useApp } from '../context/AppContext';
 import { useNotificationsContext } from '../context/NotificationsContext';
+import { AutoHidingHeader } from '../components/AutoHidingHeader';
+import { useAutoHidingHeader } from '../hooks/useAutoHidingHeader';
 import type { NotificationsStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<NotificationsStackParamList, 'Notifications'>;
@@ -59,6 +62,13 @@ export function NotificationsScreen({ navigation }: Props) {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [unreadOnly, setUnreadOnly] = useState(true);
+  const {
+    translateY,
+    statusBarHeight,
+    navBarHeight,
+    totalHeaderHeight,
+    onScroll,
+  } = useAutoHidingHeader();
 
   const visible = useMemo(() => {
     let result = matches;
@@ -145,73 +155,93 @@ export function NotificationsScreen({ navigation }: Props) {
 
   return (
     <View style={styles.container}>
-      <ScrollView
-        horizontal
-        style={styles.rulesBar}
-        contentContainerStyle={styles.rulesBarContent}
-        showsHorizontalScrollIndicator={false}
-      >
-        <TouchableOpacity
-          onPress={() => setUnreadOnly((p) => !p)}
-          style={[styles.chip, unreadOnly && styles.chipActive]}
-        >
-          <Text style={styles.chipText}>{unreadOnly ? 'Unread' : 'All'}</Text>
-        </TouchableOpacity>
-        {rules
-          .filter((r) => r.enabled)
-          .map((rule: NotificationRule) => {
-            const count = notificationsMatchingRule(rule, notifications).filter(
-              (n) => n.unread
-            ).length;
-            return (
-              <TouchableOpacity
-                key={rule.id}
-                onPress={() => applyRule(rule)}
-                disabled={count === 0}
-                style={[styles.chip, count === 0 && styles.chipDisabled]}
-              >
-                <Text style={styles.chipText}>
-                  {rule.name} ({count})
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-        <TouchableOpacity
-          onPress={() => navigation.navigate('NotificationRules')}
-          style={styles.chip}
-        >
-          <Text style={styles.chipText}>⚙ Rules</Text>
-        </TouchableOpacity>
-      </ScrollView>
-
-      {error && <Text style={styles.error}>{error}</Text>}
-
-      <FlatList
-        data={visible}
-        renderItem={renderItem}
-        keyExtractor={(m) => m.notification.id}
-        refreshControl={
-          <RefreshControl
-            refreshing={loading}
-            onRefresh={refresh}
-            tintColor="#58a6ff"
-          />
-        }
-        ListEmptyComponent={
-          !loading ? (
-            <View style={styles.emptyState}>
-              <Text style={styles.emptyTitle}>
-                {unreadOnly ? '🎉 Inbox zero' : 'No notifications'}
-              </Text>
-              <Text style={styles.emptySubtitle}>
-                {unreadOnly
-                  ? 'No unread notifications. Pull to refresh.'
-                  : 'Pull to refresh.'}
-              </Text>
-            </View>
-          ) : null
-        }
+      <AutoHidingHeader
+        title="Notifications"
+        translateY={translateY}
+        statusBarHeight={statusBarHeight}
       />
+
+      <Animated.View
+        style={[
+          styles.scrollWrapper,
+          {
+            paddingTop: totalHeaderHeight,
+            bottom: -navBarHeight,
+            transform: [{ translateY }],
+          },
+        ]}
+      >
+        <ScrollView
+          horizontal
+          style={styles.rulesBar}
+          contentContainerStyle={styles.rulesBarContent}
+          showsHorizontalScrollIndicator={false}
+        >
+          <TouchableOpacity
+            onPress={() => setUnreadOnly((p) => !p)}
+            style={[styles.chip, unreadOnly && styles.chipActive]}
+          >
+            <Text style={styles.chipText}>{unreadOnly ? 'Unread' : 'All'}</Text>
+          </TouchableOpacity>
+          {rules
+            .filter((r) => r.enabled)
+            .map((rule: NotificationRule) => {
+              const count = notificationsMatchingRule(rule, notifications).filter(
+                (n) => n.unread
+              ).length;
+              return (
+                <TouchableOpacity
+                  key={rule.id}
+                  onPress={() => applyRule(rule)}
+                  disabled={count === 0}
+                  style={[styles.chip, count === 0 && styles.chipDisabled]}
+                >
+                  <Text style={styles.chipText}>
+                    {rule.name} ({count})
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          <TouchableOpacity
+            onPress={() => navigation.navigate('NotificationRules')}
+            style={styles.chip}
+          >
+            <Text style={styles.chipText}>⚙ Rules</Text>
+          </TouchableOpacity>
+        </ScrollView>
+
+        {error && <Text style={styles.error}>{error}</Text>}
+
+        <FlatList
+          data={visible}
+          renderItem={renderItem}
+          keyExtractor={(m) => m.notification.id}
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+          contentContainerStyle={{ paddingBottom: navBarHeight }}
+          refreshControl={
+            <RefreshControl
+              refreshing={loading}
+              onRefresh={refresh}
+              tintColor="#58a6ff"
+            />
+          }
+          ListEmptyComponent={
+            !loading ? (
+              <View style={styles.emptyState}>
+                <Text style={styles.emptyTitle}>
+                  {unreadOnly ? '🎉 Inbox zero' : 'No notifications'}
+                </Text>
+                <Text style={styles.emptySubtitle}>
+                  {unreadOnly
+                    ? 'No unread notifications. Pull to refresh.'
+                    : 'Pull to refresh.'}
+                </Text>
+              </View>
+            ) : null
+          }
+        />
+      </Animated.View>
 
       {selectedIds.size > 0 && (
         <View style={styles.bulkBar}>
@@ -233,7 +263,13 @@ export function NotificationsScreen({ navigation }: Props) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#0d1117' },
+  container: { flex: 1, backgroundColor: '#0d1117', overflow: 'hidden' },
+  scrollWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
   rulesBar: { backgroundColor: '#161b22', maxHeight: 44, flexGrow: 0 },
   rulesBarContent: { paddingHorizontal: 12, paddingVertical: 8, gap: 6 },
   chip: {
@@ -303,6 +339,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
   },
   bulkBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',

--- a/mobile/src/screens/PRListScreen.tsx
+++ b/mobile/src/screens/PRListScreen.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View, FlatList, Text, TextInput, StyleSheet, RefreshControl, Linking } from 'react-native';
+import {
+  View,
+  FlatList,
+  Text,
+  TextInput,
+  StyleSheet,
+  RefreshControl,
+  Linking,
+  Animated,
+} from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { DashboardItem, OwnershipFilter } from '../../../shared/types.js';
 import { useGithubData } from '../../../shared/hooks/useGithubData.js';
@@ -13,6 +22,8 @@ import { useBadge } from '../context/BadgeContext';
 import { PRListItem } from '../components/PRListItem';
 import { FilterBar } from '../components/FilterBar';
 import { LabelFilterModal } from '../components/LabelFilterModal';
+import { AutoHidingHeader } from '../components/AutoHidingHeader';
+import { useAutoHidingHeader } from '../hooks/useAutoHidingHeader';
 import type { DashboardStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<DashboardStackParamList, 'PRList'>;
@@ -24,6 +35,13 @@ export function PRListScreen({ navigation }: Props) {
   const { markSeen, isUnseen } = useLastSeen(asyncStorageAdapter);
   const [ownershipFilter, setOwnershipFilter] = useState<OwnershipFilter>('created');
   const [labelModalVisible, setLabelModalVisible] = useState(false);
+  const {
+    translateY,
+    statusBarHeight,
+    navBarHeight,
+    totalHeaderHeight,
+    onScroll,
+  } = useAutoHidingHeader();
 
   const { items, loading, error, failedRepos, lastRefresh, refresh } = useGithubData(
     octokit,
@@ -114,85 +132,105 @@ export function PRListScreen({ navigation }: Props) {
 
   return (
     <View style={styles.container}>
-      {/* Search bar */}
-      <View style={styles.searchRow}>
-        <TextInput
-          style={styles.searchInput}
-          value={searchQuery}
-          onChangeText={setSearchQuery}
-          placeholder="Search PRs..."
-          placeholderTextColor="#484f58"
-          autoCapitalize="none"
-          autoCorrect={false}
-          clearButtonMode="while-editing"
-        />
-      </View>
-
-      {/* Filter & sort chips */}
-      <FilterBar
-        activeFilter={filter}
-        activeSort={sort}
-        sortDirection={sortDirection}
-        onFilterChange={handleSetFilter}
-        onSortChange={handleSetSort}
-        ownershipFilter={ownershipFilter}
-        onOwnershipChange={setOwnershipFilter}
-        username={username}
-        itemTypeFilter={itemTypeFilter}
-        onItemTypeChange={setItemTypeFilter}
-        prStateFilters={prStateFilters}
-        onTogglePRState={togglePRStateFilter}
-        labelFilterCount={labelFilters.size}
-        onLabelFilterPress={() => setLabelModalVisible(true)}
-        hideMyReplies={hideMyReplies}
-        onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
-        hiddenRepos={hiddenRepos}
-        onRestoreRepo={toggleRepoByName}
+      <AutoHidingHeader
+        title="Pull Requests"
+        translateY={translateY}
+        statusBarHeight={statusBarHeight}
       />
 
-      <Text style={styles.headerInfo}>{headerInfo}</Text>
-
-      {error && <Text style={styles.error}>{error}</Text>}
-
-      {failedRepos.length > 0 && (
-        <View style={styles.warningBanner}>
-          <Text style={styles.warningText}>
-            Failed to fetch: {failedRepos.map((r) => r.repo).join(', ')}
-          </Text>
+      <Animated.View
+        style={[
+          styles.scrollWrapper,
+          {
+            paddingTop: totalHeaderHeight,
+            bottom: -navBarHeight,
+            transform: [{ translateY }],
+          },
+        ]}
+      >
+        {/* Search bar */}
+        <View style={styles.searchRow}>
+          <TextInput
+            style={styles.searchInput}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            placeholder="Search PRs..."
+            placeholderTextColor="#484f58"
+            autoCapitalize="none"
+            autoCorrect={false}
+            clearButtonMode="while-editing"
+          />
         </View>
-      )}
 
-      {enabledRepos.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Text style={styles.emptyTitle}>No repositories configured</Text>
-          <Text style={styles.emptySubtitle}>
-            Go to Settings to add repositories to monitor.
-          </Text>
-        </View>
-      ) : (
-        <FlatList
-          data={filtered}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          refreshControl={
-            <RefreshControl
-              refreshing={loading}
-              onRefresh={handleRefresh}
-              tintColor="#58a6ff"
-            />
-          }
-          ListEmptyComponent={
-            !loading ? (
-              <View style={styles.emptyState}>
-                <Text style={styles.emptyTitle}>No items found</Text>
-                <Text style={styles.emptySubtitle}>
-                  Pull to refresh or adjust your filters.
-                </Text>
-              </View>
-            ) : null
-          }
+        {/* Filter & sort chips */}
+        <FilterBar
+          activeFilter={filter}
+          activeSort={sort}
+          sortDirection={sortDirection}
+          onFilterChange={handleSetFilter}
+          onSortChange={handleSetSort}
+          ownershipFilter={ownershipFilter}
+          onOwnershipChange={setOwnershipFilter}
+          username={username}
+          itemTypeFilter={itemTypeFilter}
+          onItemTypeChange={setItemTypeFilter}
+          prStateFilters={prStateFilters}
+          onTogglePRState={togglePRStateFilter}
+          labelFilterCount={labelFilters.size}
+          onLabelFilterPress={() => setLabelModalVisible(true)}
+          hideMyReplies={hideMyReplies}
+          onToggleHideMyReplies={username ? toggleHideMyReplies : undefined}
+          hiddenRepos={hiddenRepos}
+          onRestoreRepo={toggleRepoByName}
         />
-      )}
+
+        <Text style={styles.headerInfo}>{headerInfo}</Text>
+
+        {error && <Text style={styles.error}>{error}</Text>}
+
+        {failedRepos.length > 0 && (
+          <View style={styles.warningBanner}>
+            <Text style={styles.warningText}>
+              Failed to fetch: {failedRepos.map((r) => r.repo).join(', ')}
+            </Text>
+          </View>
+        )}
+
+        {enabledRepos.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No repositories configured</Text>
+            <Text style={styles.emptySubtitle}>
+              Go to Settings to add repositories to monitor.
+            </Text>
+          </View>
+        ) : (
+          <FlatList
+            data={filtered}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            contentContainerStyle={{ paddingBottom: navBarHeight }}
+            refreshControl={
+              <RefreshControl
+                refreshing={loading}
+                onRefresh={handleRefresh}
+                tintColor="#58a6ff"
+              />
+            }
+            ListEmptyComponent={
+              !loading ? (
+                <View style={styles.emptyState}>
+                  <Text style={styles.emptyTitle}>No items found</Text>
+                  <Text style={styles.emptySubtitle}>
+                    Pull to refresh or adjust your filters.
+                  </Text>
+                </View>
+              ) : null
+            }
+          />
+        )}
+      </Animated.View>
 
       <LabelFilterModal
         visible={labelModalVisible}
@@ -210,6 +248,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#0d1117',
+    overflow: 'hidden',
+  },
+  scrollWrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
   },
   searchRow: {
     backgroundColor: '#161b22',


### PR DESCRIPTION
## Summary

Implements the [iOS HIG](https://developer.apple.com/design/human-interface-guidelines/ios/bars/navigation-bars/) / [Material Design](https://material.io/components/app-bars-top#behavior) auto-hiding top app bar pattern on the mobile PR list and Notifications screens. The 44pt nav bar slides offscreen on scroll-down and reappears immediately on scroll-up, exposing an extra row of content. The status-bar inset stays opaque so the system clock/battery remain legible.

Closes #148

## Changes

- **\`mobile/src/hooks/useAutoHidingHeader.ts\`** (new) — drives the \`Animated.Value\` via a small scroll-delta threshold; always re-shows the header at the top of the list.
- **\`mobile/src/components/AutoHidingHeader.tsx\`** (new) — overlay header that mimics the React Navigation native-stack styling (\`#161b22\` background, 16pt semibold title). Status-bar inset is rendered above the animated nav bar via JSX order so the title hides cleanly behind it.
- **\`mobile/App.tsx\`** — wraps the app in \`SafeAreaProvider\` (needed for \`useSafeAreaInsets\`) and sets \`headerShown: false\` on the \`PRList\` and \`Notifications\` screens so the custom header can take over. PRDetail / NotificationRules / Settings keep their native headers (back button intact).
- **\`mobile/src/screens/PRListScreen.tsx\`** + **\`NotificationsScreen.tsx\`** — wrap the screen content in an \`Animated.View\` whose \`translateY\` matches the header's, with \`bottom: -navBarHeight\` so the FlatList actually grows by 44pt when the bar hides (instead of just shifting up and clipping at the bottom).

## Implementation notes

- Uses RN's built-in \`Animated\` API (no Reanimated dependency).
- Native driver throughout (\`useNativeDriver: true\`) — no JS-thread layout cost on scroll.
- \`scrollEventThrottle={16}\` for 60fps direction tracking.
- 6px delta threshold prevents flicker on tap/idle jitter.

## Test plan

- [ ] PR list: scroll down — title bar collapses, search/filter chips slide up to the status bar
- [ ] PR list: scroll up — header reappears immediately (no delay)
- [ ] Pull-to-refresh: header stays visible at the top
- [ ] Notifications: same behavior on the Inbox tab
- [ ] PR detail / Notification rules: native header still shown with working back button
- [ ] Verify status-bar text (clock, battery) remains readable while header is hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-hiding top headers on PR list and Notifications screens that collapse on scroll and reappear when scrolling up, maximizing content space.
  * Improved status-bar and safe-area support so headers remain visually consistent across devices.
  * Navigation headers explicitly hidden where appropriate for a cleaner bottom-tab layout.
  * Bulk-action bar now positioned to avoid overlap with content when scrolling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/landingit/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->